### PR TITLE
修复：每日构建更新 docs 后自动触发 Pages 部署

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,13 @@ on:
       - '.github/workflows/deploy.yml'
       - 'package.json'
       - 'package-lock.json'
+  # 注意：由 GitHub Actions 使用 GITHUB_TOKEN 推送的提交不会触发 push 工作流（防递归机制）
+  # 因此需要用 workflow_run 来接住「每日构建 MSM」里自动提交 docs 的场景，保证 Pages 能自动更新。
+  workflow_run:
+    workflows:
+      - 每日构建 MSM
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -24,12 +31,14 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
背景：
- 每日构建工作流会自动提交并 push 更新 `docs/zh/guide/releases.md`。
- 但该 push 由 GitHub Actions 使用 `GITHUB_TOKEN` 发起时，不会触发 `on: push` 的工作流（GitHub 防递归机制）。

改动：
- 在 `.github/workflows/deploy.yml` 增加 `workflow_run` 触发（监听工作流：`每日构建 MSM`）。
- workflow_run 场景固定 checkout `main`，确保构建到最新 docs。

验证：
- 本地 `npm run docs:build` 通过。

预期：
- 每日构建更新 releases.md 并 push 后，Pages 会在每日构建结束时自动重新部署，线上 releases 页面同步更新。