### PR TITLE
docs: 迁移 Wiki 至 doc.msmbox.net / migrate Wiki to custom domain

### DIFF
--- a/.github/docs/RELEASE_WORKFLOW_GUIDE.md
+++ b/.github/docs/RELEASE_WORKFLOW_GUIDE.md
@@ -269,7 +269,7 @@ ${commits.map(c => `- ${c.subject} (${c.author}, ${c.date})`).join('\n')}
 
 - [Anthropic API 文档](https://docs.anthropic.com/)
 - [GitHub Actions 文档](https://docs.github.com/en/actions)
-- [MSM 项目文档](https://msm9527.github.io/msm-wiki/)
+- [MSM 项目文档](https://doc.msmbox.net/)
 
 ## 支持
 

--- a/.github/workflows/daily-build-msm-beta.yml
+++ b/.github/workflows/daily-build-msm-beta.yml
@@ -107,7 +107,7 @@ jobs:
           RELEASE_NOTES_PATH="docs/zh/guide/releases-beta.md"
           LATEST_MARKER="## 🧪 最新 Beta 版本"
           HISTORY_MARKER="## 📚 历史 Beta 版本"
-          RELEASE_DOCS_URL="https://msm9527.github.io/msm-wiki/zh/guide/releases-beta.html"
+          RELEASE_DOCS_URL="https://doc.msmbox.net/zh/guide/releases-beta.html"
           INSTALL_SCRIPT_NAME="install_beta.sh"
           INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/msm9527/msm-wiki/main/install_beta.sh"
 
@@ -784,8 +784,8 @@ jobs:
 
             ## 📚 文档与支持
 
-            - 📖 [完整文档](https://msm9527.github.io/msm-wiki/)
-            - 🚀 [快速开始](https://msm9527.github.io/msm-wiki/zh/guide/install.html)
+            - 📖 [完整文档](https://doc.msmbox.net/)
+            - 🚀 [快速开始](https://doc.msmbox.net/zh/guide/install.html)
             - 📝 [版本发布](${{ needs.prepare.outputs.release_docs_url }})
             - 💬 [问题反馈](https://github.com/msm9527/msm/issues)
 
@@ -796,7 +796,7 @@ jobs:
             **🤖 由 GitHub Actions 自动构建**
 
             [![GitHub](https://img.shields.io/badge/GitHub-msm9527%2Fmsm-blue?logo=github)](https://github.com/msm9527/msm)
-            [![Documentation](https://img.shields.io/badge/docs-msm--wiki-green)](https://msm9527.github.io/msm-wiki/)
+            [![Documentation](https://img.shields.io/badge/docs-msm--wiki-green)](https://doc.msmbox.net/)
             [![Docker](https://img.shields.io/badge/docker-msmbox%2Fmsm-blue?logo=docker)](https://hub.docker.com/r/msmbox/msm)
 
             </div>
@@ -953,7 +953,7 @@ jobs:
             org.opencontainers.image.description=Mosdns Singbox Mihomo Manager
             org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
             org.opencontainers.image.source=https://github.com/msm9527/msm
-            org.opencontainers.image.url=https://msm9527.github.io/msm-wiki/
+            org.opencontainers.image.url=https://doc.msmbox.net/
           provenance: false
           sbom: false
           cache-from: type=gha

--- a/.github/workflows/daily-build-msm.yml
+++ b/.github/workflows/daily-build-msm.yml
@@ -107,7 +107,7 @@ jobs:
           RELEASE_NOTES_PATH="docs/zh/guide/releases.md"
           LATEST_MARKER="## 🚀 最新稳定版本"
           HISTORY_MARKER="## 📚 历史版本"
-          RELEASE_DOCS_URL="https://msm9527.github.io/msm-wiki/zh/guide/releases.html"
+          RELEASE_DOCS_URL="https://doc.msmbox.net/zh/guide/releases.html"
           INSTALL_SCRIPT_NAME="install.sh"
           INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/msm9527/msm-wiki/main/install.sh"
 
@@ -790,8 +790,8 @@ jobs:
 
             ## 📚 文档与支持
 
-            - 📖 [完整文档](https://msm9527.github.io/msm-wiki/)
-            - 🚀 [快速开始](https://msm9527.github.io/msm-wiki/zh/guide/install.html)
+            - 📖 [完整文档](https://doc.msmbox.net/)
+            - 🚀 [快速开始](https://doc.msmbox.net/zh/guide/install.html)
             - 📝 [版本发布](${{ needs.prepare.outputs.release_docs_url }})
             - 💬 [问题反馈](https://github.com/msm9527/msm/issues)
 
@@ -802,7 +802,7 @@ jobs:
             **🤖 由 GitHub Actions 自动构建**
 
             [![GitHub](https://img.shields.io/badge/GitHub-msm9527%2Fmsm-blue?logo=github)](https://github.com/msm9527/msm)
-            [![Documentation](https://img.shields.io/badge/docs-msm--wiki-green)](https://msm9527.github.io/msm-wiki/)
+            [![Documentation](https://img.shields.io/badge/docs-msm--wiki-green)](https://doc.msmbox.net/)
             [![Docker](https://img.shields.io/badge/docker-msmbox%2Fmsm-blue?logo=docker)](https://hub.docker.com/r/msmbox/msm)
 
             </div>
@@ -959,7 +959,7 @@ jobs:
             org.opencontainers.image.description=Mosdns Singbox Mihomo Manager
             org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
             org.opencontainers.image.source=https://github.com/msm9527/msm
-            org.opencontainers.image.url=https://msm9527.github.io/msm-wiki/
+            org.opencontainers.image.url=https://doc.msmbox.net/
           provenance: false
           sbom: false
           cache-from: type=gha

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -57,6 +57,16 @@ git push origin main
 
 配置会自动保存，无需点击保存按钮。
 
+#### 步骤 5: 绑定自定义域名
+
+1. 在 Pages 设置的 **Custom domain** 中填写 `doc.msmbox.net`
+2. 在 DNS 服务商添加 `CNAME` 记录：`doc` 指向 `msm9527.github.io`
+3. 等待 DNS 检查通过后启用 **Enforce HTTPS**
+
+::: warning DNS 目标
+CNAME 必须直接指向 `msm9527.github.io`，不要填写 `msm9527.github.io/msm-wiki`。
+:::
+
 ### 3. 触发首次部署
 
 ```bash
@@ -80,8 +90,8 @@ git push origin main
 
 部署成功后，可以通过以下地址访问：
 
-- **中文文档**: https://msm9527.github.io/msm-wiki/zh/
-- **English Docs**: https://msm9527.github.io/msm-wiki/en/
+- **中文文档**: https://doc.msmbox.net/zh/
+- **English Docs**: https://doc.msmbox.net/en/
 
 ## 本地开发
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -245,7 +245,7 @@ add name=msm remote-image=msmbox/msm:latest interface=veth-msm envlists=msm_envs
 ## 资源
 
 - [项目主页](https://github.com/msm9527/msm)
-- [完整文档](https://msm9527.github.io/msm-wiki/)
+- [完整文档](https://doc.msmbox.net/)
 - [Docker Hub](https://hub.docker.com/r/msmbox/msm)
 - [问题反馈](https://github.com/msm9527/msm/issues)
 

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -121,9 +121,9 @@ docker run -d \
 
 ## 📚 文档
 
-- 📖 [完整文档](https://msm9527.github.io/msm-wiki/)
-- 🚀 [快速开始](https://msm9527.github.io/msm-wiki/zh/guide/getting-started.html)
-- 💾 [安装部署](https://msm9527.github.io/msm-wiki/zh/guide/install.html)
+- 📖 [完整文档](https://doc.msmbox.net/)
+- 🚀 [快速开始](https://doc.msmbox.net/zh/guide/getting-started.html)
+- 💾 [安装部署](https://doc.msmbox.net/zh/guide/install.html)
 
 ## 🔗 相关链接
 

--- a/FIX_CSS_ISSUE.md
+++ b/FIX_CSS_ISSUE.md
@@ -1,17 +1,17 @@
-# 问题修复说明
+# 自定义域名资源路径说明
 
 ## 问题描述
 
-访问 https://msm9527.github.io/msm-wiki/zh/ 时，页面可以访问但没有任何 UI 和 CSS 样式。
+访问 https://doc.msmbox.net/zh/ 时，如果继续使用原来的 `/msm-wiki/` 子路径，CSS、JavaScript 和图片会请求错误地址。
 
 ## 问题原因
 
 VitePress 的 `base` 配置不正确。
 
-- **错误配置**: `base: '/'`
-- **正确配置**: `base: '/msm-wiki/'`
+- **错误配置**: `base: '/msm-wiki/'`
+- **正确配置**: `base: '/'`
 
-GitHub Pages 将项目部署在 `https://msm9527.github.io/msm-wiki/` 路径下，所以所有静态资源（CSS、JS、图片）的路径都需要加上 `/msm-wiki/` 前缀。
+GitHub Pages 现在使用独立域名 `https://doc.msmbox.net/`，站点直接部署在域名根路径，静态资源不再使用 `/msm-wiki/` 前缀。
 
 ## 修复内容
 
@@ -21,11 +21,10 @@ GitHub Pages 将项目部署在 `https://msm9527.github.io/msm-wiki/` 路径下�
 export default defineConfig({
   title: "MSM Wiki",
   description: "MSM Manager - 统一管理平台文档",
-  base: '/msm-wiki/',  // 修改这里
-  ignoreDeadLinks: true,
+  base: '/',  // 自定义域名使用根路径
 
   head: [
-    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/msm-wiki/logo/favicon.svg' }],  // 修改这里
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo/favicon.svg' }],
     // ...
   ],
   // ...
@@ -43,8 +42,8 @@ export default defineConfig({
 
 等待 GitHub Actions 部署完成（约 2-3 分钟），然后访问：
 
-- https://msm9527.github.io/msm-wiki/zh/
-- https://msm9527.github.io/msm-wiki/en/
+- https://doc.msmbox.net/zh/
+- https://doc.msmbox.net/en/
 
 现在应该可以看到完整的 UI 和样式了。
 
@@ -64,27 +63,27 @@ export default defineConfig({
 
 ### 为什么需要 base 配置？
 
-当 VitePress 站点部署在子路径下时（如 `/msm-wiki/`），所有资源的引用路径都需要加上这个前缀：
+当 VitePress 站点部署在自定义域名根路径时，所有资源都应直接从根路径加载：
 
-- CSS: `/msm-wiki/assets/style.css`
-- JS: `/msm-wiki/assets/app.js`
-- 图片: `/msm-wiki/logo/logo.svg`
+- CSS: `/assets/style.css`
+- JS: `/assets/app.js`
+- 图片: `/logo/logo.svg`
+
+如果 `base` 仍配置为 `/msm-wiki/`，VitePress 会生成：
+- CSS: `/msm-wiki/assets/style.css` ❌ (404)
+- JS: `/msm-wiki/assets/app.js` ❌ (404)
 
 如果 `base` 配置为 `/`，VitePress 会生成：
-- CSS: `/assets/style.css` ❌ (404)
-- JS: `/assets/app.js` ❌ (404)
-
-如果 `base` 配置为 `/msm-wiki/`，VitePress 会生成：
-- CSS: `/msm-wiki/assets/style.css` ✅
-- JS: `/msm-wiki/assets/app.js` ✅
+- CSS: `/assets/style.css` ✅
+- JS: `/assets/app.js` ✅
 
 ### 本地开发
 
-本地开发时，访问 `http://localhost:5173/msm-wiki/` 即可看到正确的效果。
+本地开发时，访问 `http://localhost:5173/` 即可看到正确的效果。
 
 ### 自定义域名
 
-如果将来使用自定义域名（如 `wiki.example.com`），则需要将 `base` 改回 `/`。
+当前自定义域名为 `doc.msmbox.net`，GitHub Pages 中的 Custom domain 必须与此值保持一致。
 
 ## 总结
 

--- a/GITHUB_PAGES_SETUP.md
+++ b/GITHUB_PAGES_SETUP.md
@@ -35,7 +35,13 @@ git push origin main
    - **Source** 下拉菜单选择 **GitHub Actions**
    - 配置会自动保存
 
-4. **等待部署**
+4. **配置自定义域名**
+   - 在 **Custom domain** 中填写 `doc.msmbox.net` 并保存
+   - 在 DNS 服务商添加 `CNAME` 记录：`doc` 指向 `msm9527.github.io`
+   - CNAME 目标不要附加 `/msm-wiki` 路径
+   - DNS 检查通过后启用 **Enforce HTTPS**
+
+5. **等待部署**
    - 返回仓库首页
    - 点击 **Actions** 标签
    - 查看 "Deploy Wiki to GitHub Pages" 工作流
@@ -44,8 +50,8 @@ git push origin main
 ### 第三步：访问 Wiki
 
 部署成功后，访问：
-- https://msm9527.github.io/msm-wiki/zh/ （中文）
-- https://msm9527.github.io/msm-wiki/en/ （英文）
+- https://doc.msmbox.net/zh/ （中文）
+- https://doc.msmbox.net/en/ （英文）
 
 ## 常见问题
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
   <p>Mosdns Singbox Manager - 统一管理平台文档</p>
 
   <p>
-    <a href="https://msm9527.github.io/msm-wiki/zh/">中文文档</a> •
-    <a href="https://msm9527.github.io/msm-wiki/en/">English Docs</a>
+    <a href="https://doc.msmbox.net/zh/">中文文档</a> •
+    <a href="https://doc.msmbox.net/en/">English Docs</a>
   </p>
 </div>
 
@@ -21,8 +21,8 @@
 
 ## 🌐 在线访问
 
-- **中文文档**: https://msm9527.github.io/msm-wiki/zh/
-- **English Docs**: https://msm9527.github.io/msm-wiki/en/
+- **中文文档**: https://doc.msmbox.net/zh/
+- **English Docs**: https://doc.msmbox.net/en/
 
 ## 🚀 本地开发
 

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -608,7 +608,7 @@ div[class*='language-'] pre {
 1. 首页: /Users/doumao/code/github/msm-wiki/.playwright-mcp/refactored-homepage.png
 2. 文档页: /Users/doumao/code/github/msm-wiki/.playwright-mcp/refactored-doc-page.png
 
-你可以在浏览器中访问 http://localhost:5173/msm-wiki/zh/ 查看实时效果。
+你可以在浏览器中访问 http://localhost:5173/zh/ 查看实时效果。
 
 🎯 当前效果特点
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -4,10 +4,10 @@ import { defineConfig } from 'vitepress'
 export default defineConfig({
   title: "MSM Wiki",
   description: "MSM Manager - 统一管理平台文档",
-  base: '/msm-wiki/',
+  base: '/',
 
   head: [
-    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/msm-wiki/logo/favicon.svg' }],
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo/favicon.svg' }],
     ['meta', { name: 'theme-color', content: '#2563eb' }],
     ['meta', { name: 'og:type', content: 'website' }],
     ['meta', { name: 'og:locale', content: 'zh_CN' }],

--- a/install.sh
+++ b/install.sh
@@ -822,7 +822,7 @@ show_info() {
     echo "安装位置: /usr/local/bin/msm"
     echo "配置目录: ${MSM_CONFIG_DIR}"
     echo ""
-    echo "文档地址: https://msm9527.github.io/msm-wiki/zh/"
+    echo "文档地址: https://doc.msmbox.net/zh/"
     echo "=========================================="
 }
 

--- a/install_beta.sh
+++ b/install_beta.sh
@@ -827,7 +827,7 @@ show_info() {
     echo "安装位置: /usr/local/bin/msm"
     echo "配置目录: ${MSM_CONFIG_DIR}"
     echo ""
-    echo "文档地址: https://msm9527.github.io/msm-wiki/zh/"
+    echo "文档地址: https://doc.msmbox.net/zh/"
     echo "=========================================="
 }
 

--- a/install_beta_cn.sh
+++ b/install_beta_cn.sh
@@ -787,7 +787,7 @@ show_info() {
     echo "安装位置: /usr/local/bin/msm"
     echo "配置目录: ${MSM_CONFIG_DIR}"
     echo ""
-    echo "文档地址: https://msm9527.github.io/msm-wiki/zh/"
+    echo "文档地址: https://doc.msmbox.net/zh/"
     echo "=========================================="
 }
 

--- a/install_cn.sh
+++ b/install_cn.sh
@@ -786,7 +786,7 @@ show_info() {
     echo "安装位置: /usr/local/bin/msm"
     echo "配置目录: ${MSM_CONFIG_DIR}"
     echo ""
-    echo "文档地址: https://msm9527.github.io/msm-wiki/zh/"
+    echo "文档地址: https://doc.msmbox.net/zh/"
     echo "=========================================="
 }
 


### PR DESCRIPTION
## 变更

- 将 VitePress `base` 从 `/msm-wiki/` 切换为自定义域名根路径 `/`
- 将公开文档、安装脚本、发布工作流和 Docker 元数据中的文档地址迁移到 `https://doc.msmbox.net/`
- 更新 GitHub Pages 和 DNS 配置说明

## 验证

- `npm test`：9/9 通过
- `CI=1 npm run docs:build`：通过
- 生成 HTML 中 CSS、JS、favicon 与导航均使用根路径
- `bash -n` 检查 4 个安装脚本通过
- `git diff --check`：通过

## DNS

合并后将 GitHub Pages Custom domain 设为 `doc.msmbox.net`；DNS 需添加 `CNAME doc -> msm9527.github.io`。