### PR TITLE
feat(docs): 文档页标题上方加分组眉标 / section eyebrow on doc pages

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -353,6 +353,31 @@ export default {
       setupMobileDrawer()
       setupScrollReveal()
       setupScrollProgress()
+      setupDocEyebrow()
+    }
+
+    // 文档页在 h1 上方注入一条等宽小眉标，显示当前所属的侧栏分组
+    // （如"快速上手"），把文档页和首页的标注语汇统一起来。
+    // 分组名取自侧栏里高亮的 level-0 分组；取不到就不注入。
+    function setupDocEyebrow() {
+      const h1 = document.querySelector<HTMLElement>('.VPDoc .vp-doc h1')
+      if (!h1) return
+
+      // 路由切换后重建，先移除旧的
+      document.querySelector('.msm-doc-eyebrow')?.remove()
+
+      const groupLabel = document
+        .querySelector<HTMLElement>(
+          '.VPSidebar .VPSidebarItem.level-0.has-active > .item .text'
+        )
+        ?.textContent?.trim()
+
+      if (!groupLabel) return
+
+      const eyebrow = document.createElement('div')
+      eyebrow.className = 'msm-doc-eyebrow'
+      eyebrow.textContent = groupLabel
+      h1.parentElement?.insertBefore(eyebrow, h1)
     }
 
     if (document.readyState === 'loading') {

--- a/docs/.vitepress/theme/style/content.css
+++ b/docs/.vitepress/theme/style/content.css
@@ -8,6 +8,30 @@
 
 /* ==================== 标题 ==================== */
 
+/*
+ * 文档页眉标：h1 上方一条等宽小标签（当前侧栏分组名），前缀一段琥珀短线，
+ * 呼应首页 Hero 的品牌名标注。由 theme/index.ts 注入到 h1 之前。
+ */
+.vp-doc .msm-doc-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--msm-space-3);
+  margin-bottom: var(--msm-space-4);
+  font-family: var(--msm-font-mono);
+  font-size: var(--msm-text-label);
+  font-weight: var(--msm-weight-medium);
+  letter-spacing: var(--msm-tracking-label);
+  text-transform: uppercase;
+  color: var(--msm-ink-3);
+}
+
+.vp-doc .msm-doc-eyebrow::before {
+  content: '';
+  width: 20px;
+  height: 2px;
+  background: var(--msm-accent);
+}
+
 .vp-doc h1 {
   font-size: var(--msm-text-4xl);
   font-weight: var(--msm-weight-bold);


### PR DESCRIPTION
## 概述 / Overview
文档页 h1 上方加一条等宽小眉标（当前侧栏分组名 + 琥珀短线），补上下文并呼应首页标注语汇。
A small monospace section eyebrow (sidebar group + amber tick) above each doc h1 - adds context and matches the home's label vocabulary.

## 改动 / Changes
- `theme/index.ts`: setupDocEyebrow 从高亮的 level-0 侧栏分组取名注入 h1 之前，路由切换重建
- `content.css`: `.msm-doc-eyebrow` 样式（等宽大写 + 琥珀短线）

## 测试 / Test plan
- [x] build 通过；分组名随页面正确切换（快速上手 / 界面功能 / 法律与合规）
- [x] 首页不受影响；明暗、桌面、移动核对，无横向溢出，无控制台报错
- [x] `npm test` 13 通过 / 2 既有失败（无关）
- [ ] 合并后线上抽查几页确认