### PR TITLE
发布 OpenWrt 多架构包与 LuCI 插件 / Add native OpenWrt releases

### DIFF
--- a/.github/openwrt/README.md
+++ b/.github/openwrt/README.md
@@ -1,0 +1,70 @@
+# OpenWrt package builder
+
+The release workflows reuse the static Linux release archive and build native
+`msm` and `luci-app-msm` packages without an OpenWrt SDK:
+
+```sh
+python3 .github/openwrt/build-packages.py \
+  --version 1.5.0 --target linux-arm64 \
+  --input dist/msm-1.5.0-linux-arm64.tar.gz \
+  --output-dir dist/openwrt --format all --with-luci
+```
+
+Python 3.9+ builds IPK directly. APK v3 uses upstream `apk mkpkg`, either a native
+apk-tools 3 executable (`--apk-bin` / `APK_BIN`, with root or fakeroot), or one
+Docker container running `alpine:3.23`. `--format ipk` needs no Docker. APK fixes
+compatibility at apk 3.0.0 and uses deflate compression because OpenWrt's apk build
+does not require zstd.
+
+The input must contain a static Linux ELF named `msm`. When present,
+`THIRD_PARTY_NOTICES.md`, `OSS_PROVENANCE.md`, and
+`licenses/CADDY-APACHE-2.0.txt` are included as well (older stable versions predate
+the Caddy integration and these files). The binary and legal documents are preserved
+byte for byte. Architecture mismatches, ELF interpreter/shared-library dependencies,
+duplicate entries and symbolic links in required files are rejected. Other
+archive entries are not extracted.
+
+| Release target | OpenWrt package architectures |
+| --- | --- |
+| `linux-amd64` | `x86_64` |
+| `linux-arm64` | `aarch64_generic`, `aarch64_cortex-a53`, `aarch64_cortex-a72` |
+| `linux-armv7` | `arm_cortex-a7_neon-vfpv4`, `arm_cortex-a9_vfpv3-d16`, `arm_cortex-a9_neon`, `arm_cortex-a15_neon-vfpv4` |
+| `linux-armv6` | `arm_arm1176jzf-s_vfp` |
+
+Use repeatable `--arch` options to select architectures within a target. LuCI is
+built once by the amd64 job, or for another target with `--with-luci`. IPK uses
+`Architecture: all` and APK uses `arch:noarch` for LuCI; filenames use `all` for
+both formats. APK filenames include the architecture so release matrix outputs
+cannot overwrite one another.
+
+Stable versions map to `1.5.0-r1`. `beta-1.5.0` maps to `1.5.0~beta-r1` for opkg
+and `1.5.0_beta-r1` for apk, so a stable package supersedes its matching beta.
+`--release` changes the package revision. `SOURCE_DATE_EPOCH` defaults to zero.
+
+The UCI section is `msm.main` (type `msm`): `enabled=0`,
+`config_dir=/etc/msm`, `port=7777`. The package enables the procd boot script;
+the UCI switch controls whether it starts MSM. Installation always reloads the
+service to register its config-change trigger, including when disabled, so the
+first LuCI Save & Apply can start it. Upgrades restart an enabled service,
+preserve edited UCI configuration and do not touch application data.
+New data directories use a `logs` symlink to `/tmp/msm/logs`; existing log
+directories are left intact. The default data directory and UCI file are listed
+for sysupgrade preservation. Users selecting another storage location should
+include it in their own backup policy.
+
+```sh
+node --test test/openwrt-package*.test.cjs
+MSM_TEST_APK=1 node --test test/openwrt-package-apk.test.cjs
+```
+
+The optional integration test performs real APK v3 installation, upgrade and
+removal in an isolated root, checking permissions, edited configuration and
+database preservation. Regular tests parse IPK archives and execute the service
+and package lifecycle scripts with controlled OpenWrt command fixtures.
+
+Format references:
+
+- [OpenWrt IPK builder](https://github.com/openwrt/openwrt/blob/main/scripts/ipkg-build)
+- [OpenWrt package generation and APK metadata](https://github.com/openwrt/openwrt/blob/main/include/package-pack.mk)
+- [Upstream apk mkpkg](https://gitlab.alpinelinux.org/alpine/apk-tools/-/blob/master/doc/apk-mkpkg.8.scd)
+- [OpenWrt apk usage](https://openwrt.org/docs/guide-user/additional-software/apk)

--- a/.github/openwrt/build-packages.py
+++ b/.github/openwrt/build-packages.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Build native OpenWrt IPK and APK v3 packages from a static MSM release archive.
+
+IPK layout follows openwrt/openwrt scripts/ipkg-build. APK is always generated
+by upstream apk mkpkg, as in OpenWrt include/package-pack.mk; no APK v2 encoder.
+Python 3.9+ is sufficient for IPK. APK additionally needs apk-tools 3 + fakeroot
+(unless running as root), or Docker. No OpenWrt SDK or target compiler is used.
+"""
+
+import argparse
+import gzip
+import hashlib
+import io
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import shlex
+import struct
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+HERE = Path(__file__).resolve().parent
+ARCHITECTURES = {
+    "linux-amd64": (62, 2, ["x86_64"]),
+    "linux-arm64": (183, 2, ["aarch64_generic", "aarch64_cortex-a53", "aarch64_cortex-a72"]),
+    "linux-armv7": (40, 1, ["arm_cortex-a7_neon-vfpv4", "arm_cortex-a9_vfpv3-d16", "arm_cortex-a9_neon", "arm_cortex-a15_neon-vfpv4"]),
+    "linux-armv6": (40, 1, ["arm_arm1176jzf-s_vfp"]),
+}
+APK_IMAGE = "alpine:3.23"
+RELEASE_DOCUMENTS = ("THIRD_PARTY_NOTICES.md", "OSS_PROVENANCE.md", "licenses/CADDY-APACHE-2.0.txt")
+
+
+def package_version(version, release):
+    """Return APK's version; build_ipk translates prerelease ordering to '~'."""
+    beta = version.startswith("beta-")
+    value = version[5:] if beta else version
+    value = value.removeprefix("v")
+    match = re.fullmatch(r"(\d+(?:\.\d+)*)(?:[-_](alpha|beta|pre|rc)(?:[.-]?(\d+))?)?", value)
+    if not match:
+        raise ValueError("version must be numeric (for example 1.5.0, v1.5.0, beta-1.5.0 or 1.5.0-rc.1)")
+    base, stage, number = match.groups()
+    if beta and stage and stage != "beta":
+        raise ValueError("beta prefix conflicts with version prerelease suffix")
+    stage = stage or ("beta" if beta else None)
+    return base + ("_" + stage + (number or "") if stage else "") + "-r" + str(release)
+
+
+def read_release(archive, target):
+    # Read just one regular file. Never extract arbitrary archive paths/symlinks.
+    with tarfile.open(archive, "r:gz") as tar:
+        files = {}
+        for name in ("msm",) + RELEASE_DOCUMENTS:
+            candidates = [m for m in tar.getmembers() if PurePosixPath(m.name).as_posix() == name]
+            # Older stable releases predate the embedded Caddy integration and
+            # do not include these notices. Preserve every notice when present.
+            if not candidates and name != "msm":
+                continue
+            if len(candidates) != 1 or not candidates[0].isfile():
+                raise ValueError("release archive must contain one regular " + name + " file")
+            files[name] = tar.extractfile(candidates[0]).read()
+    validate_elf(files["msm"], target)
+    return files
+
+
+def validate_elf(binary, target):
+    machine, elf_class, _ = ARCHITECTURES[target]
+    if len(binary) < 64 or binary[:4] != b"\x7fELF" or binary[4] != elf_class or binary[5] != 1:
+        raise ValueError("msm must be a little-endian Linux ELF matching " + target)
+    if struct.unpack_from("<H", binary, 18)[0] != machine:
+        raise ValueError("ELF machine does not match " + target)
+    if elf_class == 2:
+        phoff = struct.unpack_from("<Q", binary, 32)[0]
+        phentsize, phnum = struct.unpack_from("<HH", binary, 54)
+        minimum = 56
+    else:
+        phoff = struct.unpack_from("<I", binary, 28)[0]
+        phentsize, phnum = struct.unpack_from("<HH", binary, 42)
+        minimum = 32
+    if phnum == 0 or phentsize < minimum or phoff + phentsize * phnum > len(binary):
+        raise ValueError("malformed ELF program headers")
+    for index in range(phnum):
+        offset = phoff + index * phentsize
+        kind = struct.unpack_from("<I", binary, offset)[0]
+        if kind == 3:  # PT_INTERP
+            raise ValueError("dynamically linked MSM cannot be packaged; use the static Linux release")
+        if kind == 2:  # PT_DYNAMIC: reject DT_NEEDED even for binaries without PT_INTERP.
+            if elf_class == 2:
+                start = struct.unpack_from("<Q", binary, offset + 8)[0]
+                size = struct.unpack_from("<Q", binary, offset + 32)[0]
+                step, fmt = 16, "<Q"
+            else:
+                start = struct.unpack_from("<I", binary, offset + 4)[0]
+                size = struct.unpack_from("<I", binary, offset + 16)[0]
+                step, fmt = 8, "<I"
+            if start + size > len(binary):
+                raise ValueError("malformed ELF dynamic section")
+            for pos in range(start, start + size, step):
+                tag = struct.unpack_from(fmt, binary, pos)[0]
+                if tag == 0:
+                    break
+                if tag == 1:
+                    raise ValueError("ELF has shared-library dependencies; use a static Linux release")
+
+
+def write(path, contents, mode=0o644):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(contents if isinstance(contents, bytes) else contents.encode())
+    path.chmod(mode)
+
+
+def prepare_tree(root, name, release_files):
+    shutil.copytree(HERE / "files" / name, root)
+    for path in root.rglob("*"):
+        path.chmod(0o755 if path.is_dir() or path.name == "msm" and path.parent.name == "init.d" else 0o644)
+    if name == "msm":
+        write(root / "usr/bin/msm", release_files["msm"], 0o755)
+        for document in RELEASE_DOCUMENTS:
+            if document in release_files:
+                write(root / "usr/share/doc/msm" / document, release_files[document])
+    root.chmod(0o755)
+
+
+def scripts_for(name, kind):
+    if name == "msm":
+        if kind == "ipk":
+            return {"postinst": "msm-postinst", "prerm": "msm-prerm"}
+        return {"post-install": "msm-postinst", "post-upgrade": "msm-postinst", "pre-upgrade": "msm-pre-upgrade", "pre-deinstall": "msm-prerm"}
+    if kind == "ipk":
+        return {"postinst": "luci-postinst", "postrm": "luci-postinst"}
+    return {"post-install": "luci-postinst", "post-upgrade": "luci-postinst", "post-deinstall": "luci-postinst"}
+
+
+def tar_gz(entries, epoch):
+    out = io.BytesIO()
+    with gzip.GzipFile(fileobj=out, mode="wb", filename="", mtime=epoch) as gz:
+        with tarfile.open(fileobj=gz, mode="w", format=tarfile.GNU_FORMAT) as tar:
+            for name, data, mode, is_dir in entries:
+                info = tarfile.TarInfo("./" + name)
+                info.uid = info.gid = 0
+                info.uname = info.gname = "root"
+                info.mtime = epoch
+                info.mode = mode
+                info.size = 0 if is_dir else len(data)
+                if is_dir:
+                    info.type = tarfile.DIRTYPE
+                tar.addfile(info, None if is_dir else io.BytesIO(data))
+    return out.getvalue()
+
+
+def tree_entries(root):
+    return [(p.relative_to(root).as_posix(), b"" if p.is_dir() else p.read_bytes(), p.stat().st_mode & 0o777, p.is_dir()) for p in sorted(root.rglob("*"))]
+
+
+def metadata(name):
+    if name == "msm":
+        return "MSM DNS and network services manager", ["procd", "uci", "ca-bundle"]
+    return "LuCI configuration and Web UI launcher for MSM", ["msm", "luci-base"]
+
+
+def build_ipk(root, name, version, arch, output, epoch):
+    # opkg follows Debian ordering: '~beta' sorts below the corresponding stable
+    # release. APK uses '_beta' for the same semantic ordering instead.
+    version = version.replace("_", "~", 1)
+    description, dependencies = metadata(name)
+    data = tar_gz(tree_entries(root), epoch)
+    fields = {"Package": name, "Version": version, "Architecture": arch, "Maintainer": "MSM Team", "Section": "net" if name == "msm" else "luci", "Priority": "optional", "License": "Proprietary", "Depends": ", ".join(dependencies), "Installed-Size": str(len(gzip.decompress(data))), "Source": "https://github.com/msm9527/msm", "Description": description}
+    controls = [("control", ("\n".join(k + ": " + v for k, v in fields.items()) + "\n").encode(), 0o644, False)]
+    for phase, script in scripts_for(name, "ipk").items():
+        controls.append((phase, (HERE / "scripts" / script).read_bytes(), 0o755, False))
+    if name == "msm":
+        controls.append(("conffiles", b"/etc/config/msm\n", 0o644, False))
+    package = tar_gz([("debian-binary", b"2.0\n", 0o644, False), ("data.tar.gz", data, 0o644, False), ("control.tar.gz", tar_gz(controls, epoch), 0o644, False)], epoch)
+    path = output / (name + "_" + version + "_" + arch + ".ipk")
+    path.write_bytes(package)
+    return path
+
+
+def apk_command(explicit):
+    binary = explicit or os.environ.get("APK_BIN") or shutil.which("apk")
+    if binary:
+        if not shutil.which(binary):
+            raise ValueError("APK_BIN / --apk-bin must name an executable apk-tools 3 binary")
+        prefix = []
+        if os.geteuid() != 0:
+            fakeroot = shutil.which("fakeroot")
+            if fakeroot:
+                prefix = [fakeroot]
+            elif explicit or os.environ.get("APK_BIN"):
+                raise ValueError("native apk requires root or fakeroot to record root-owned package files")
+            else:
+                binary = None
+        if binary:
+            result = subprocess.run([binary, "--version"], check=True, capture_output=True, text=True)
+            if not re.search(r"apk-tools 3\.", result.stdout):
+                raise ValueError("APK v3 requires apk-tools 3 with the mkpkg command")
+            return prefix + [binary]
+    if not shutil.which("docker"):
+        raise ValueError("APK v3 needs apk-tools 3 + fakeroot, or Docker (alpine:3.23); use --format ipk for IPK only")
+    return None
+
+
+def build_apk(root, name, version, arch, output, epoch, native, work, docker_jobs):
+    description, dependencies = metadata(name)
+    # OpenWrt's sysupgrade helpers consume these files in addition to APK's own
+    # protected /etc semantics. Keep generated application data out of payloads.
+    info_dir = root / "lib/apk/packages"
+    if name == "msm":
+        config = root / "etc/config/msm"
+        write(info_dir / (name + ".conffiles"), "/etc/config/msm\n")
+        write(info_dir / (name + ".conffiles_static"), "/etc/config/msm " + hashlib.sha256(config.read_bytes()).hexdigest() + "\n")
+    paths = sorted("/" + p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file())
+    write(info_dir / (name + ".list"), "\n".join(paths) + "\n")
+    filename = name + "-" + version + "_" + arch + ".apk"
+    temporary_output = work / filename
+    # OpenWrt builds apk without zstd: always use portable deflate explicitly.
+    args = ["mkpkg", "--compat", "3.0.0", "--compression", "deflate", "--info", "name:" + name, "--info", "version:" + version,
+            "--info", "arch:" + ("noarch" if arch == "all" else arch), "--info", "description:" + description,
+            "--info", "license:Proprietary", "--info", "origin:msm", "--info", "url:https://github.com/msm9527/msm",
+            "--info", "maintainer:MSM Team", "--info", "depends:" + " ".join(dependencies)]
+    scripts_dir = work / "scripts"
+    scripts_dir.mkdir(exist_ok=True)
+    for phase, script in scripts_for(name, "apk").items():
+        target = scripts_dir / script
+        shutil.copyfile(HERE / "scripts" / script, target)
+        args.extend(["--script", phase + ":" + (str(target) if native else "/work/scripts/" + script)])
+    environment = dict(os.environ, SOURCE_DATE_EPOCH=str(epoch))
+    if native:
+        args.extend(["--files", str(root), "--output", str(temporary_output)])
+        subprocess.run(native[:-1] + ["sh", "-ec", 'chown -R 0:0 "$1"; shift; exec "$@"', "build-apk", str(root), native[-1]] + args, check=True, env=environment)
+    else:
+        args.extend(["--files", "/tmp/package", "--output", "/work/" + filename])
+        docker_jobs.append("cp -a " + shlex.quote("/work/" + root.name) + " /tmp/package\nchown -R 0:0 /tmp/package\n" + shlex.join(["apk"] + args) + "\nrm -rf /tmp/package\n")
+        return output / filename
+    return finish_apk(temporary_output, output)
+
+
+def finish_apk(temporary_output, output):
+    if temporary_output.read_bytes()[:3] != b"ADB":
+        raise ValueError("apk mkpkg did not produce an APK v3 (ADB) file")
+    path = output / temporary_output.name
+    shutil.copyfile(temporary_output, path)
+    return path
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--release", type=int, default=1)
+    parser.add_argument("--target", required=True, choices=ARCHITECTURES)
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--format", choices=["ipk", "apk", "all"], default="all")
+    parser.add_argument("--arch", action="append", help="Build only these package architectures from the target's supported list")
+    parser.add_argument("--with-luci", action="store_true", help="Also build LuCI; automatic for linux-amd64")
+    parser.add_argument("--apk-bin", help="Use a native apk-tools 3 executable")
+    parser.add_argument("--apk-image", default=APK_IMAGE, help="Docker APK builder image (default: %(default)s)")
+    args = parser.parse_args()
+    if args.release < 1:
+        parser.error("--release must be positive")
+    try:
+        version = package_version(args.version, args.release)
+        arches = args.arch or ARCHITECTURES[args.target][2]
+        if any(arch not in ARCHITECTURES[args.target][2] for arch in arches):
+            raise ValueError("architecture is not supported by target " + args.target)
+        release_files = read_release(args.input, args.target)
+        native = apk_command(args.apk_bin) if args.format != "ipk" else None
+        epoch = int(os.environ.get("SOURCE_DATE_EPOCH", "0"))
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        packages = []
+        with tempfile.TemporaryDirectory(prefix="msm-openwrt-") as temporary:
+            work = Path(temporary)
+            docker_jobs = []
+            entries = [("msm", arch) for arch in arches]
+            if args.with_luci or args.target == "linux-amd64":
+                entries.append(("luci-app-msm", "all"))
+            for name, arch in entries:
+                root = work / (name + "-" + arch)
+                prepare_tree(root, name, release_files)
+                if args.format != "apk":
+                    packages.append(build_ipk(root, name, version, arch, args.output_dir, epoch))
+                if args.format != "ipk":
+                    packages.append(build_apk(root, name, version, arch, args.output_dir, epoch, native, work, docker_jobs))
+            if docker_jobs:
+                # One container per target, copying before chown so host files
+                # retain their ownership. Network is unnecessary after image pull.
+                write(work / "build-apks.sh", "#!/bin/sh\nset -eu\n" + "\n".join(docker_jobs), 0o755)
+                subprocess.run(["docker", "run", "--rm", "--network", "none", "-e", "SOURCE_DATE_EPOCH=" + str(epoch), "-v", str(work) + ":/work", args.apk_image, "sh", "/work/build-apks.sh"], check=True)
+                for path in packages:
+                    if path.suffix == ".apk":
+                        finish_apk(work / path.name, args.output_dir)
+        for path in packages:
+            print(path)
+    except (ValueError, OSError, tarfile.TarError, subprocess.CalledProcessError, struct.error) as error:
+        parser.exit(1, "error: " + str(error) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/openwrt/files/luci-app-msm/usr/share/luci/menu.d/luci-app-msm.json
+++ b/.github/openwrt/files/luci-app-msm/usr/share/luci/menu.d/luci-app-msm.json
@@ -1,0 +1,8 @@
+{
+  "admin/services/msm": {
+    "title": "MSM",
+    "order": 90,
+    "action": { "type": "view", "path": "msm" },
+    "depends": { "acl": ["luci-app-msm"], "uci": { "msm": true } }
+  }
+}

--- a/.github/openwrt/files/luci-app-msm/usr/share/rpcd/acl.d/luci-app-msm.json
+++ b/.github/openwrt/files/luci-app-msm/usr/share/rpcd/acl.d/luci-app-msm.json
@@ -1,0 +1,7 @@
+{
+  "luci-app-msm": {
+    "description": "Configure MSM service",
+    "read": { "uci": ["msm"], "ubus": { "service": ["list"] } },
+    "write": { "uci": ["msm"] }
+  }
+}

--- a/.github/openwrt/files/luci-app-msm/www/luci-static/resources/view/msm.js
+++ b/.github/openwrt/files/luci-app-msm/www/luci-static/resources/view/msm.js
@@ -1,0 +1,67 @@
+'use strict';
+'require view';
+'require form';
+'require uci';
+'require rpc';
+'require poll';
+
+var callServiceList = rpc.declare({
+	object: 'service', method: 'list', params: ['name'], expect: { '': {} }
+});
+var callGetPort = rpc.declare({
+	object: 'uci', method: 'get', params: ['config', 'section', 'option'], expect: { value: '7777' }
+});
+
+return view.extend({
+	load: function() {
+		return Promise.all([uci.load('msm'), callServiceList('msm')]);
+	},
+	render: function(data) {
+		var m = new form.Map('msm', _('MSM'),
+			_('Manage the MSM service. Enable it and Save & Apply, then open the Web UI to complete setup.'));
+		var s = m.section(form.NamedSection, 'main', 'msm');
+		s.anonymous = true;
+		s.addremove = false;
+		var o = s.option(form.Flag, 'enabled', _('Enable'));
+		o.rmempty = false;
+		o = s.option(form.Value, 'port', _('Web UI port'));
+		o.datatype = 'port';
+		o.default = '7777';
+		o.rmempty = false;
+		o = s.option(form.Value, 'config_dir', _('Data directory'),
+			_('Stores configuration, database, logs and downloaded services. Use persistent storage with enough free space. Changing this path does not move existing data.'));
+		o.default = '/etc/msm';
+		o.rmempty = false;
+		o.validate = function(section, value) {
+			return value && value.charAt(0) === '/' && value !== '/' && !/\/\/|(^|\/)\.{1,2}(\/|$)|[\r\n\0]/.test(value) ? true : _('Use an absolute directory path other than / without dot components or repeated slashes.');
+		};
+		return m.render().then(function(map) {
+			var host = window.location.hostname;
+			if (host.indexOf(':') !== -1 && host.charAt(0) !== '[') host = '[' + host + ']';
+			var status = E('span');
+			var link = E('a', {
+				'class': 'cbi-button cbi-button-action',
+				'target': '_blank', 'rel': 'noopener noreferrer'
+			}, _('Open MSM Web UI'));
+			function update(service, port) {
+				var instances = ((service || {}).msm || {}).instances || {};
+				var running = Object.keys(instances).some(function(key) { return instances[key].running; });
+				status.textContent = running ? _('Running') : _('Stopped');
+				var validPort = /^\d+$/.test(port) && Number(port) >= 1 && Number(port) <= 65535;
+				link.setAttribute('href', validPort ? 'http://' + host + ':' + port + '/' : '#');
+			}
+			update(data[1], uci.get('msm', 'main', 'port') || '7777');
+			poll.add(function() {
+				// Read committed UCI through RPC without unloading form state, so
+				// polling never discards edits that have not yet been saved.
+				return Promise.all([callServiceList('msm'), callGetPort('msm', 'main', 'port')])
+					.then(function(values) { update(values[0], values[1]); })
+					.catch(function() { status.textContent = _('Unavailable'); });
+			}, 5);
+			return E('div', {}, [
+				E('p', {}, [_('Service status: '), status]),
+				E('p', {}, link), map
+			]);
+		});
+	}
+});

--- a/.github/openwrt/files/msm/etc/config/msm
+++ b/.github/openwrt/files/msm/etc/config/msm
@@ -1,0 +1,4 @@
+config msm 'main'
+	option enabled '0'
+	option config_dir '/etc/msm'
+	option port '7777'

--- a/.github/openwrt/files/msm/etc/init.d/msm
+++ b/.github/openwrt/files/msm/etc/init.d/msm
@@ -1,0 +1,46 @@
+#!/bin/sh /etc/rc.common
+# MSM_OPENWRT_PACKAGE
+# OpenWrt rc.common reads these variables; BusyBox ash supports local.
+# shellcheck disable=SC2034,SC3043
+
+USE_PROCD=1
+START=99
+STOP=10
+
+start_service() {
+	local enabled config_dir port
+	config_load msm
+	config_get_bool enabled main enabled 0
+	[ "$enabled" = 1 ] || return 0
+	config_get config_dir main config_dir /etc/msm
+	config_get port main port 7777
+	case "$config_dir" in
+		/|*//*|/../*|/..|/./*|/.|/*/../*|/*/..|/*/./*|/*/.) logger -t msm 'config_dir must be a normalized directory other than /'; return 1 ;;
+		/*) ;;
+		*) logger -t msm 'config_dir must be an absolute path'; return 1 ;;
+	esac
+	case "$port" in
+		''|*[!0-9]*) logger -t msm 'port must be an integer'; return 1 ;;
+	esac
+	[ "$port" -ge 1 ] && [ "$port" -le 65535 ] || return 1
+	if [ ! -d "$config_dir" ]; then
+		(umask 077; mkdir -p "$config_dir") || return 1
+	fi
+	(umask 077; mkdir -p /tmp/msm/logs) || return 1
+	if [ ! -e "$config_dir/logs" ] && [ ! -L "$config_dir/logs" ]; then
+		ln -s /tmp/msm/logs "$config_dir/logs" || return 1
+	fi
+	procd_open_instance
+	procd_set_param command /usr/bin/msm serve -c "$config_dir" -p "$port"
+	procd_set_param env MSM_DISABLE_CONSOLE_LOG=1
+	procd_set_param respawn 3600 5 5
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param term_timeout 30
+	procd_set_param file /etc/config/msm
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger msm
+}

--- a/.github/openwrt/files/msm/lib/upgrade/keep.d/msm
+++ b/.github/openwrt/files/msm/lib/upgrade/keep.d/msm
@@ -1,0 +1,2 @@
+/etc/config/msm
+/etc/msm/

--- a/.github/openwrt/scripts/luci-postinst
+++ b/.github/openwrt/scripts/luci-postinst
@@ -1,0 +1,9 @@
+#!/bin/sh
+[ -z "${IPKG_INSTROOT:-}" ] || exit 0
+[ "${IPKG_NO_SCRIPT:-0}" != 1 ] || exit 0
+# LuCI uses hashed JSON cache names on current OpenWrt; retain cleanup of the
+# unsuffixed name for older releases as well (see upstream luci/luci.mk).
+rm -f /tmp/luci-indexcache /tmp/luci-indexcache.*
+rm -rf /tmp/luci-modulecache
+[ ! -x /etc/init.d/rpcd ] || /etc/init.d/rpcd reload
+exit 0

--- a/.github/openwrt/scripts/msm-postinst
+++ b/.github/openwrt/scripts/msm-postinst
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Package installation must never start services inside an image build root.
+[ -z "${IPKG_INSTROOT:-}" ] || exit 0
+[ "${IPKG_NO_SCRIPT:-0}" != 1 ] || exit 0
+/etc/init.d/msm enable
+# Register procd's config.change trigger even when MSM is disabled. Without an
+# initial reload, the first LuCI Save & Apply has no service trigger to invoke.
+# start_service checks UCI enabled before creating any process instance.
+/etc/init.d/msm reload
+exit 0

--- a/.github/openwrt/scripts/msm-pre-upgrade
+++ b/.github/openwrt/scripts/msm-pre-upgrade
@@ -1,0 +1,5 @@
+#!/bin/sh
+[ -z "${IPKG_INSTROOT:-}" ] || exit 0
+[ "${IPKG_NO_SCRIPT:-0}" != 1 ] || exit 0
+[ ! -x /etc/init.d/msm ] || /etc/init.d/msm stop
+exit 0

--- a/.github/openwrt/scripts/msm-prerm
+++ b/.github/openwrt/scripts/msm-prerm
@@ -1,0 +1,10 @@
+#!/bin/sh
+[ -z "${IPKG_INSTROOT:-}" ] || exit 0
+[ "${IPKG_NO_SCRIPT:-0}" != 1 ] || exit 0
+/etc/init.d/msm stop
+case "${1:-}" in
+	upgrade) ;;
+	*) /etc/init.d/msm disable ;;
+esac
+# Configuration and application data are intentionally retained.
+exit 0

--- a/.github/workflows/daily-build-msm-beta.yml
+++ b/.github/workflows/daily-build-msm-beta.yml
@@ -309,6 +309,17 @@ jobs:
           ref: ${{ needs.prepare.outputs.commit_sha }}
           token: ${{ secrets.MSM_REPO_TOKEN }}
 
+      - name: 验证 OpenWrt 运行时兼容性
+        if: matrix.target == 'linux-amd64' || matrix.target == 'linux-arm64' || matrix.target == 'linux-armv7' || matrix.target == 'linux-armv6'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f scripts/check-openwrt-compatibility.sh ]; then
+            echo "error: MSM 源码缺少 OpenWrt 兼容性检查；请先合入 procd 和网络规则归属修复" >&2
+            exit 1
+          fi
+          bash scripts/check-openwrt-compatibility.sh
+
       - name: Checkout 当前仓库（msm-wiki）用于派网 APX 模板
         if: matrix.target == 'linux-amd64' || matrix.target == 'linux-arm64'
         continue-on-error: true
@@ -391,9 +402,13 @@ jobs:
 
           test -d dist
 
-          rm -rf ../backend/cmd/msm/frontend/dist
-          mkdir -p ../backend/cmd/msm/frontend
-          cp -r dist ../backend/cmd/msm/frontend/
+          if [ -f ../scripts/prepare-embedded-frontend.sh ]; then
+            bash ../scripts/prepare-embedded-frontend.sh
+          else
+            rm -rf ../backend/cmd/msm/frontend/dist
+            mkdir -p ../backend/cmd/msm/frontend
+            cp -r dist ../backend/cmd/msm/frontend/
+          fi
 
       - name: 编译 MSM（发布加固版）
         shell: bash
@@ -422,17 +437,27 @@ jobs:
           bash ./scripts/verify-executable-sha256.sh "dist/msm"
           chmod +x dist/msm
 
-          mkdir -p dist/licenses
-          cp THIRD_PARTY_NOTICES.md dist/THIRD_PARTY_NOTICES.md
-          cp docs/OSS_PROVENANCE.md dist/OSS_PROVENANCE.md
-          cp licenses/CADDY-APACHE-2.0.txt dist/licenses/CADDY-APACHE-2.0.txt
+          PACKAGE_FILES=(msm)
+          NOTICE_SOURCES=(THIRD_PARTY_NOTICES.md docs/OSS_PROVENANCE.md licenses/CADDY-APACHE-2.0.txt)
+          # 含 Caddy 的版本必须携带完整声明；旧版源码按实际存在的文件打包。
+          if grep -Eq '^[[:space:]]*(require[[:space:]]+)?github\.com/caddyserver/caddy/v2([[:space:]]|$)' backend/go.mod; then
+            for source in "${NOTICE_SOURCES[@]}"; do
+              if [ ! -f "${source}" ]; then
+                echo "error: 含 Caddy 的发布版本缺少开源声明: ${source}" >&2
+                exit 1
+              fi
+            done
+          fi
+          for source in "${NOTICE_SOURCES[@]}"; do
+            [ -f "${source}" ] || continue
+            destination="${source#docs/}"
+            mkdir -p "dist/$(dirname "${destination}")"
+            cp "${source}" "dist/${destination}"
+            PACKAGE_FILES+=("${destination}")
+          done
 
-          # 发布包使用合并后的单一 MSM 二进制，并携带开源声明。
-          tar -czf "dist/msm-${VERSION}-${{ matrix.target }}.tar.gz" -C dist \
-            msm \
-            THIRD_PARTY_NOTICES.md \
-            OSS_PROVENANCE.md \
-            licenses/CADDY-APACHE-2.0.txt
+          # 发布包始终包含单一 MSM 二进制，保留该源码版本实际提供的开源声明。
+          tar -czf "dist/msm-${VERSION}-${{ matrix.target }}.tar.gz" -C dist "${PACKAGE_FILES[@]}"
           tar -tzf "dist/msm-${VERSION}-${{ matrix.target }}.tar.gz" | grep -Fx msm >/dev/null
           if tar -tzf "dist/msm-${VERSION}-${{ matrix.target }}.tar.gz" | grep -Eq '(^|/)msm-edge(\.exe)?$'; then
             echo "error: 新版发布包不应再包含 msm-edge 可执行文件" >&2
@@ -483,9 +508,67 @@ jobs:
           path: dist/msm-${{ needs.prepare.outputs.version }}-${{ matrix.target }}-panabit.apx
           if-no-files-found: ignore
 
+  openwrt:
+    name: OpenWrt IPK / APK（${{ matrix.target }}）
+    needs: [prepare, build]
+    if: needs.prepare.outputs.skip != 'true'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [linux-amd64, linux-arm64, linux-armv7, linux-armv6]
+    steps:
+      - name: Checkout 当前仓库（msm-wiki）用于 OpenWrt 打包
+        uses: actions/checkout@v4
+
+      - name: 下载对应架构的 MSM 发布包
+        uses: actions/download-artifact@v4
+        with:
+          name: msm-${{ needs.prepare.outputs.version }}-${{ matrix.target }}
+          path: dist
+
+      - name: 生成 OpenWrt 原生安装包与 LuCI 插件
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.prepare.outputs.version }}"
+          python3 .github/openwrt/build-packages.py \
+            --version "${VERSION}" \
+            --target "${{ matrix.target }}" \
+            --input "dist/msm-${VERSION}-${{ matrix.target }}.tar.gz" \
+            --output-dir dist/openwrt \
+            --format all
+          compgen -G 'dist/openwrt/msm_*.ipk' >/dev/null
+          compgen -G 'dist/openwrt/msm-*.apk' >/dev/null
+          if [ "${{ matrix.target }}" = linux-amd64 ]; then
+            compgen -G 'dist/openwrt/luci-app-msm_*.ipk' >/dev/null
+            compgen -G 'dist/openwrt/luci-app-msm-*.apk' >/dev/null
+          fi
+
+      - name: Setup Node.js for OpenWrt checks
+        if: matrix.target == 'linux-amd64'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: 验证真实 APK 安装、升级和卸载
+        if: matrix.target == 'linux-amd64'
+        env:
+          MSM_TEST_APK: '1'
+        run: node --test test/openwrt-package*.test.cjs
+
+      - name: 上传 OpenWrt IPK / APK 产物
+        uses: actions/upload-artifact@v4
+        with:
+          name: msm-${{ needs.prepare.outputs.version }}-openwrt-${{ matrix.target }}
+          path: |
+            dist/openwrt/*.ipk
+            dist/openwrt/*.apk
+          if-no-files-found: error
+
   release:
     name: 发布构建产物（${{ needs.prepare.outputs.channel_name }}）
-    needs: [prepare, build]
+    needs: [prepare, build, openwrt]
     if: needs.prepare.outputs.skip != 'true'
     runs-on: ubuntu-24.04
     steps:
@@ -506,11 +589,42 @@ jobs:
           set -euo pipefail
           VERSION="${{ needs.prepare.outputs.version }}"
 
-          mapfile -t RELEASE_FILES < <(find dist -type f \( -name "msm-${VERSION}-*.tar.gz" -o -name "msm-${VERSION}-*-panabit.apx" \) | sort)
+          mapfile -t RELEASE_FILES < <(find dist -type f \( -name "msm-${VERSION}-*.tar.gz" -o -name "msm-${VERSION}-*-panabit.apx" -o -name 'msm_*.ipk' -o -name 'msm-*.apk' -o -name 'luci-app-msm_*.ipk' -o -name 'luci-app-msm-*.apk' \) | sort)
           if [ "${#RELEASE_FILES[@]}" -eq 0 ]; then
             echo "error: 没有找到任何可发布附件" >&2
             exit 1
           fi
+
+          mapfile -t OPENWRT_FILES < <(find dist -type f \( -name 'msm_*.ipk' -o -name 'msm-*.apk' -o -name 'luci-app-msm_*.ipk' -o -name 'luci-app-msm-*.apk' \) | sort)
+          if [ "${#OPENWRT_FILES[@]}" -eq 0 ]; then
+            echo "error: 缺少 OpenWrt 安装包，拒绝发布不完整版本" >&2
+            exit 1
+          fi
+          OPENWRT_SECTION="$(printf '%s\n' \
+            '### 📡 OpenWrt 原生安装包（IPK / APK + LuCI）' \
+            '' \
+            'OpenWrt 24.10 及以前使用 IPK（opkg），25.12 及以后使用 APK（apk v3）。选择与设备包架构匹配的 msm 包，再安装同版本 luci-app-msm 插件。' \
+            '' \
+            '[安装、架构选择与校验说明](https://doc.msmbox.net/zh/guide/install-openwrt.html)' \
+            '' \
+            '<details>' \
+            '<summary><b>下载 OpenWrt 软件包（x86_64 / ARM64 / ARMv7 / ARMv6）</b></summary>' \
+            '' \
+            '| 文件 | 格式 |' \
+            '|------|------|')"
+          for file in "${OPENWRT_FILES[@]}"; do
+            base="$(basename "${file}")"
+            OPENWRT_SECTION="${OPENWRT_SECTION}
+            | [\`${base}\`](https://github.com/msm9527/msm-wiki/releases/download/${VERSION}/${base}) | ${base##*.} |"
+          done
+          OPENWRT_SECTION="${OPENWRT_SECTION}
+
+            </details>"
+          {
+            echo "openwrt_section<<EOF"
+            printf '%s\n' "${OPENWRT_SECTION}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
           CHECKSUM_FILE="dist/SHA256SUMS"
           : > "${CHECKSUM_FILE}"
@@ -528,7 +642,7 @@ jobs:
 
           mapfile -t APX_FILES < <(find dist -type f -name "msm-${VERSION}-*-panabit.apx" | sort)
           if [ "${#APX_FILES[@]}" -eq 0 ]; then
-            echo "download_note=同一发布页内提供各平台二进制、安装包与 SHA256 校验清单" >> "$GITHUB_OUTPUT"
+            echo "download_note=同一发布页内提供各平台二进制、OpenWrt IPK/APK、LuCI 插件与 SHA256 校验清单" >> "$GITHUB_OUTPUT"
             echo "panabit_section=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -569,7 +683,7 @@ jobs:
 
             </details>"
 
-          echo "download_note=同一发布页内提供各平台二进制、安装包、派网 APX 与 SHA256 校验清单" >> "$GITHUB_OUTPUT"
+          echo "download_note=同一发布页内提供各平台二进制、OpenWrt IPK/APK、LuCI 插件、派网 APX 与 SHA256 校验清单" >> "$GITHUB_OUTPUT"
           {
             echo "panabit_section<<EOF"
             printf '%s\n' "${SECTION}"
@@ -680,6 +794,8 @@ jobs:
 
             </details>
 
+            ${{ steps.release_assets.outputs.openwrt_section }}
+
             ${{ steps.release_assets.outputs.panabit_section }}
 
             <details>
@@ -718,7 +834,9 @@ jobs:
 
             ## 🚀 快速安装
 
-            ### 一键安装脚本（推荐）
+            OpenWrt 请使用上方的原生软件包，按 [OpenWrt 安装指南](https://doc.msmbox.net/zh/guide/install-openwrt.html) 操作。
+
+            ### 一键安装脚本（Linux / macOS）
 
             ```bash
             curl -fsSL ${{ needs.prepare.outputs.install_script_url }} | sudo bash
@@ -795,6 +913,7 @@ jobs:
           prerelease: ${{ needs.prepare.outputs.is_beta }}
           allowUpdates: true
           replacesArtifacts: true
+          artifactErrorsFailBuild: true
           artifacts: ${{ steps.release_assets.outputs.paths }}
 
       - name: 校正 GitHub Release 发布状态
@@ -972,7 +1091,7 @@ jobs:
           set -euo pipefail
           VERSION="${{ needs.prepare.outputs.version }}"
           mkdir -p upload/"${VERSION}"
-          find dist -type f -name "msm-${VERSION}-*.tar.gz" -exec cp {} upload/"${VERSION}"/ \;
+          find dist -type f \( -name "msm-${VERSION}-*.tar.gz" -o -name "msm-${VERSION}-*-panabit.apx" -o -name 'msm_*.ipk' -o -name 'msm-*.apk' -o -name 'luci-app-msm_*.ipk' -o -name 'luci-app-msm-*.apk' \) -exec cp {} upload/"${VERSION}"/ \;
           CHECKSUM_FILE="$(find dist -type f -name SHA256SUMS | head -n 1)"
           if [ -z "${CHECKSUM_FILE}" ]; then
             echo "error: 未找到 SHA256SUMS" >&2

--- a/.github/workflows/daily-build-msm.yml
+++ b/.github/workflows/daily-build-msm.yml
@@ -313,6 +313,17 @@ jobs:
           ref: ${{ needs.prepare.outputs.commit_sha }}
           token: ${{ secrets.MSM_REPO_TOKEN }}
 
+      - name: 验证 OpenWrt 运行时兼容性
+        if: matrix.target == 'linux-amd64' || matrix.target == 'linux-arm64' || matrix.target == 'linux-armv7' || matrix.target == 'linux-armv6'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f scripts/check-openwrt-compatibility.sh ]; then
+            echo "error: MSM 源码缺少 OpenWrt 兼容性检查；请先合入 procd 和网络规则归属修复" >&2
+            exit 1
+          fi
+          bash scripts/check-openwrt-compatibility.sh
+
       - name: Checkout 当前仓库（msm-wiki）用于派网 APX 模板
         if: matrix.target == 'linux-amd64' || matrix.target == 'linux-arm64'
         continue-on-error: true
@@ -395,9 +406,13 @@ jobs:
 
           test -d dist
 
-          rm -rf ../backend/cmd/msm/frontend/dist
-          mkdir -p ../backend/cmd/msm/frontend
-          cp -r dist ../backend/cmd/msm/frontend/
+          if [ -f ../scripts/prepare-embedded-frontend.sh ]; then
+            bash ../scripts/prepare-embedded-frontend.sh
+          else
+            rm -rf ../backend/cmd/msm/frontend/dist
+            mkdir -p ../backend/cmd/msm/frontend
+            cp -r dist ../backend/cmd/msm/frontend/
+          fi
 
       - name: 编译 MSM（发布加固版）
         shell: bash
@@ -426,17 +441,27 @@ jobs:
           bash ./scripts/verify-executable-sha256.sh "dist/msm"
           chmod +x dist/msm
 
-          mkdir -p dist/licenses
-          cp THIRD_PARTY_NOTICES.md dist/THIRD_PARTY_NOTICES.md
-          cp docs/OSS_PROVENANCE.md dist/OSS_PROVENANCE.md
-          cp licenses/CADDY-APACHE-2.0.txt dist/licenses/CADDY-APACHE-2.0.txt
+          PACKAGE_FILES=(msm)
+          NOTICE_SOURCES=(THIRD_PARTY_NOTICES.md docs/OSS_PROVENANCE.md licenses/CADDY-APACHE-2.0.txt)
+          # 含 Caddy 的版本必须携带完整声明；旧版源码按实际存在的文件打包。
+          if grep -Eq '^[[:space:]]*(require[[:space:]]+)?github\.com/caddyserver/caddy/v2([[:space:]]|$)' backend/go.mod; then
+            for source in "${NOTICE_SOURCES[@]}"; do
+              if [ ! -f "${source}" ]; then
+                echo "error: 含 Caddy 的发布版本缺少开源声明: ${source}" >&2
+                exit 1
+              fi
+            done
+          fi
+          for source in "${NOTICE_SOURCES[@]}"; do
+            [ -f "${source}" ] || continue
+            destination="${source#docs/}"
+            mkdir -p "dist/$(dirname "${destination}")"
+            cp "${source}" "dist/${destination}"
+            PACKAGE_FILES+=("${destination}")
+          done
 
-          # 发布包使用合并后的单一 MSM 二进制，并携带开源声明。
-          tar -czf "dist/msm-${VERSION}-${{ matrix.target }}.tar.gz" -C dist \
-            msm \
-            THIRD_PARTY_NOTICES.md \
-            OSS_PROVENANCE.md \
-            licenses/CADDY-APACHE-2.0.txt
+          # 发布包始终包含单一 MSM 二进制，保留该源码版本实际提供的开源声明。
+          tar -czf "dist/msm-${VERSION}-${{ matrix.target }}.tar.gz" -C dist "${PACKAGE_FILES[@]}"
           tar -tzf "dist/msm-${VERSION}-${{ matrix.target }}.tar.gz" | grep -Fx msm >/dev/null
           if tar -tzf "dist/msm-${VERSION}-${{ matrix.target }}.tar.gz" | grep -Eq '(^|/)msm-edge(\.exe)?$'; then
             echo "error: 新版发布包不应再包含 msm-edge 可执行文件" >&2
@@ -487,9 +512,67 @@ jobs:
           path: dist/msm-${{ needs.prepare.outputs.version }}-${{ matrix.target }}-panabit.apx
           if-no-files-found: ignore
 
+  openwrt:
+    name: OpenWrt IPK / APK（${{ matrix.target }}）
+    needs: [prepare, build]
+    if: needs.prepare.outputs.skip != 'true'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [linux-amd64, linux-arm64, linux-armv7, linux-armv6]
+    steps:
+      - name: Checkout 当前仓库（msm-wiki）用于 OpenWrt 打包
+        uses: actions/checkout@v4
+
+      - name: 下载对应架构的 MSM 发布包
+        uses: actions/download-artifact@v4
+        with:
+          name: msm-${{ needs.prepare.outputs.version }}-${{ matrix.target }}
+          path: dist
+
+      - name: 生成 OpenWrt 原生安装包与 LuCI 插件
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.prepare.outputs.version }}"
+          python3 .github/openwrt/build-packages.py \
+            --version "${VERSION}" \
+            --target "${{ matrix.target }}" \
+            --input "dist/msm-${VERSION}-${{ matrix.target }}.tar.gz" \
+            --output-dir dist/openwrt \
+            --format all
+          compgen -G 'dist/openwrt/msm_*.ipk' >/dev/null
+          compgen -G 'dist/openwrt/msm-*.apk' >/dev/null
+          if [ "${{ matrix.target }}" = linux-amd64 ]; then
+            compgen -G 'dist/openwrt/luci-app-msm_*.ipk' >/dev/null
+            compgen -G 'dist/openwrt/luci-app-msm-*.apk' >/dev/null
+          fi
+
+      - name: Setup Node.js for OpenWrt checks
+        if: matrix.target == 'linux-amd64'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: 验证真实 APK 安装、升级和卸载
+        if: matrix.target == 'linux-amd64'
+        env:
+          MSM_TEST_APK: '1'
+        run: node --test test/openwrt-package*.test.cjs
+
+      - name: 上传 OpenWrt IPK / APK 产物
+        uses: actions/upload-artifact@v4
+        with:
+          name: msm-${{ needs.prepare.outputs.version }}-openwrt-${{ matrix.target }}
+          path: |
+            dist/openwrt/*.ipk
+            dist/openwrt/*.apk
+          if-no-files-found: error
+
   release:
     name: 发布构建产物（${{ needs.prepare.outputs.channel_name }}）
-    needs: [prepare, build]
+    needs: [prepare, build, openwrt]
     if: needs.prepare.outputs.skip != 'true'
     runs-on: ubuntu-24.04
     steps:
@@ -510,11 +593,42 @@ jobs:
           set -euo pipefail
           VERSION="${{ needs.prepare.outputs.version }}"
 
-          mapfile -t RELEASE_FILES < <(find dist -type f \( -name "msm-${VERSION}-*.tar.gz" -o -name "msm-${VERSION}-*-panabit.apx" \) | sort)
+          mapfile -t RELEASE_FILES < <(find dist -type f \( -name "msm-${VERSION}-*.tar.gz" -o -name "msm-${VERSION}-*-panabit.apx" -o -name 'msm_*.ipk' -o -name 'msm-*.apk' -o -name 'luci-app-msm_*.ipk' -o -name 'luci-app-msm-*.apk' \) | sort)
           if [ "${#RELEASE_FILES[@]}" -eq 0 ]; then
             echo "error: 没有找到任何可发布附件" >&2
             exit 1
           fi
+
+          mapfile -t OPENWRT_FILES < <(find dist -type f \( -name 'msm_*.ipk' -o -name 'msm-*.apk' -o -name 'luci-app-msm_*.ipk' -o -name 'luci-app-msm-*.apk' \) | sort)
+          if [ "${#OPENWRT_FILES[@]}" -eq 0 ]; then
+            echo "error: 缺少 OpenWrt 安装包，拒绝发布不完整版本" >&2
+            exit 1
+          fi
+          OPENWRT_SECTION="$(printf '%s\n' \
+            '### 📡 OpenWrt 原生安装包（IPK / APK + LuCI）' \
+            '' \
+            'OpenWrt 24.10 及以前使用 IPK（opkg），25.12 及以后使用 APK（apk v3）。选择与设备包架构匹配的 msm 包，再安装同版本 luci-app-msm 插件。' \
+            '' \
+            '[安装、架构选择与校验说明](https://doc.msmbox.net/zh/guide/install-openwrt.html)' \
+            '' \
+            '<details>' \
+            '<summary><b>下载 OpenWrt 软件包（x86_64 / ARM64 / ARMv7 / ARMv6）</b></summary>' \
+            '' \
+            '| 文件 | 格式 |' \
+            '|------|------|')"
+          for file in "${OPENWRT_FILES[@]}"; do
+            base="$(basename "${file}")"
+            OPENWRT_SECTION="${OPENWRT_SECTION}
+            | [\`${base}\`](https://github.com/msm9527/msm-wiki/releases/download/${VERSION}/${base}) | ${base##*.} |"
+          done
+          OPENWRT_SECTION="${OPENWRT_SECTION}
+
+            </details>"
+          {
+            echo "openwrt_section<<EOF"
+            printf '%s\n' "${OPENWRT_SECTION}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
           CHECKSUM_FILE="dist/SHA256SUMS"
           : > "${CHECKSUM_FILE}"
@@ -532,7 +646,7 @@ jobs:
 
           mapfile -t APX_FILES < <(find dist -type f -name "msm-${VERSION}-*-panabit.apx" | sort)
           if [ "${#APX_FILES[@]}" -eq 0 ]; then
-            echo "download_note=同一发布页内提供各平台二进制、安装包与 SHA256 校验清单" >> "$GITHUB_OUTPUT"
+            echo "download_note=同一发布页内提供各平台二进制、OpenWrt IPK/APK、LuCI 插件与 SHA256 校验清单" >> "$GITHUB_OUTPUT"
             echo "panabit_section=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -573,7 +687,7 @@ jobs:
 
             </details>"
 
-          echo "download_note=同一发布页内提供各平台二进制、安装包、派网 APX 与 SHA256 校验清单" >> "$GITHUB_OUTPUT"
+          echo "download_note=同一发布页内提供各平台二进制、OpenWrt IPK/APK、LuCI 插件、派网 APX 与 SHA256 校验清单" >> "$GITHUB_OUTPUT"
           {
             echo "panabit_section<<EOF"
             printf '%s\n' "${SECTION}"
@@ -684,6 +798,8 @@ jobs:
 
             </details>
 
+            ${{ steps.release_assets.outputs.openwrt_section }}
+
             ${{ steps.release_assets.outputs.panabit_section }}
 
             <details>
@@ -722,7 +838,9 @@ jobs:
 
             ## 🚀 快速安装
 
-            ### 一键安装脚本（推荐）
+            OpenWrt 请使用上方的原生软件包，按 [OpenWrt 安装指南](https://doc.msmbox.net/zh/guide/install-openwrt.html) 操作。
+
+            ### 一键安装脚本（Linux / macOS）
 
             ```bash
             curl -fsSL ${{ needs.prepare.outputs.install_script_url }} | sudo bash
@@ -799,6 +917,7 @@ jobs:
           prerelease: ${{ needs.prepare.outputs.is_beta }}
           allowUpdates: true
           replacesArtifacts: true
+          artifactErrorsFailBuild: true
           artifacts: ${{ steps.release_assets.outputs.paths }}
 
       - name: 校正 GitHub Release 发布状态
@@ -976,7 +1095,7 @@ jobs:
           set -euo pipefail
           VERSION="${{ needs.prepare.outputs.version }}"
           mkdir -p upload/"${VERSION}"
-          find dist -type f -name "msm-${VERSION}-*.tar.gz" -exec cp {} upload/"${VERSION}"/ \;
+          find dist -type f \( -name "msm-${VERSION}-*.tar.gz" -o -name "msm-${VERSION}-*-panabit.apx" -o -name 'msm_*.ipk' -o -name 'msm-*.apk' -o -name 'luci-app-msm_*.ipk' -o -name 'luci-app-msm-*.apk' \) -exec cp {} upload/"${VERSION}"/ \;
           CHECKSUM_FILE="$(find dist -type f -name SHA256SUMS | head -n 1)"
           if [ -z "${CHECKSUM_FILE}" ]; then
             echo "error: 未找到 SHA256SUMS" >&2

--- a/.github/workflows/openwrt-check.yml
+++ b/.github/workflows/openwrt-check.yml
@@ -1,0 +1,66 @@
+name: OpenWrt 包与发布校验
+
+on:
+  pull_request:
+    paths:
+      - '.github/openwrt/**'
+      - '.github/workflows/openwrt-check.yml'
+      - '.github/workflows/daily-build-msm.yml'
+      - '.github/workflows/daily-build-msm-beta.yml'
+      - 'test/openwrt-package*.test.cjs'
+      - 'test/release-workflow.test.cjs'
+  push:
+    branches: [codex/openwrt-packages]
+    paths:
+      - '.github/openwrt/**'
+      - '.github/workflows/openwrt-check.yml'
+      - '.github/workflows/daily-build-msm.yml'
+      - '.github/workflows/daily-build-msm-beta.yml'
+      - 'test/openwrt-package*.test.cjs'
+      - 'test/release-workflow.test.cjs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openwrt-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: OpenWrt package validation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Wiki
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: 校验 Actions 工作流
+        shell: bash
+        run: |
+          set -euo pipefail
+          ACTIONLINT_ARCHIVE="${RUNNER_TEMP}/actionlint_1.7.12_linux_amd64.tar.gz"
+          curl --fail --silent --show-error --location --retry 3 \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz \
+            --output "${ACTIONLINT_ARCHIVE}"
+          printf '%s  %s\n' \
+            '8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8' \
+            "${ACTIONLINT_ARCHIVE}" | sha256sum -c -
+          tar -xzf "${ACTIONLINT_ARCHIVE}" -C "${RUNNER_TEMP}" actionlint
+          "${RUNNER_TEMP}/actionlint" -shellcheck= \
+            .github/workflows/openwrt-check.yml \
+            .github/workflows/daily-build-msm.yml \
+            .github/workflows/daily-build-msm-beta.yml
+
+      - name: 验证 IPK / APK 生命周期与发布集成
+        env:
+          MSM_TEST_APK: '1'
+        run: node --test test/openwrt-package*.test.cjs test/release-workflow.test.cjs

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -113,6 +113,7 @@ export default defineConfig({
             { text: 'Linux 安装', link: '/zh/guide/install-linux' },
             { text: 'macOS 安装', link: '/zh/guide/install-macos' },
             { text: 'Alpine 安装', link: '/zh/guide/install-alpine' },
+            { text: 'OpenWrt 安装', link: '/zh/guide/install-openwrt' },
             { text: 'Docker 安装', link: '/zh/guide/docker' },
             { text: '首次使用', link: '/zh/guide/first-use' },
             { text: '完整使用流程', link: '/zh/guide/complete-workflow' }

--- a/docs/zh/guide/install-openwrt.md
+++ b/docs/zh/guide/install-openwrt.md
@@ -1,0 +1,162 @@
+# OpenWrt 安装
+
+将 MSM 直接安装到 OpenWrt 路由器时，使用发布页的 **`msm` 原生软件包 + `luci-app-msm` 插件**。`msm` 包提供程序、UCI 配置和 procd 服务；LuCI 插件在「服务 → MSM」中提供启停配置、状态和 Web 控制台入口。
+
+如果 MSM 运行在另一台服务器，只需要让 OpenWrt 接入它，请阅读 [OpenWrt 路由与 DNS 配置](/zh/guide/openwrt)。
+
+## 选择包格式和架构
+
+OpenWrt 24.10 及以前使用 **opkg / `.ipk`**；25.12 及以后使用 **apk v3 / `.apk`**。衍生固件以实际安装的包管理器为准。[OpenWrt 官方安装说明](https://openwrt.org/faq/how_to_install_packages)
+
+通过 SSH 在路由器上执行：
+
+```sh
+cat /etc/openwrt_release
+if command -v apk >/dev/null 2>&1; then
+    apk --print-arch
+else
+    opkg print-architecture
+fi
+df -h
+free -m
+```
+
+按包管理器返回的架构选择 `msm` 文件，不要仅凭 `uname -m` 猜测。尤其 ARM64 设备虽然都显示 `aarch64`，软件包架构仍可能不同。
+
+| 硬件 | 软件包架构 | 对应程序 |
+| --- | --- | --- |
+| Intel / AMD 64 位软路由 | `x86_64` | Linux amd64，兼容基础 x86-64 指令集 |
+| ARM64 路由器、开发板 | `aarch64_generic`、`aarch64_cortex-a53`、`aarch64_cortex-a72` | Linux arm64 |
+| ARMv7 设备 | `arm_cortex-a7_neon-vfpv4`、`arm_cortex-a9_vfpv3-d16`、`arm_cortex-a9_neon`、`arm_cortex-a15_neon-vfpv4` | Linux armv7 |
+| ARMv6 设备 | `arm_arm1176jzf-s_vfp` | Linux armv6 |
+| LuCI 插件 | `all` | 所有受支持架构通用 |
+
+没有匹配架构时，不要通过强制架构参数安装其他 CPU 的包。当前发布包不包含 MIPS 或 32 位 x86 版本。
+
+程序使用静态 Go 构建，不依赖 glibc。安装后，数据库和下载的 DNS / 代理内核仍需要额外的持久化空间；小容量闪存设备可以先准备外接存储，再配置数据目录。
+
+## 下载和校验
+
+- [稳定版发布页](https://github.com/msm9527/msm-wiki/releases/latest)
+- [全部发布记录（包含 Beta）](https://github.com/msm9527/msm-wiki/releases)
+- 国内镜像：稳定版目录为 `https://msm.19930520.xyz/dl/<发布标签>/`，Beta 目录为 `https://msm.19930520.xyz/dl/beta/<发布标签>/`。
+
+在同一个发布版本中下载三个文件：**一个匹配架构的 `msm` 包、一个同格式的 `luci-app-msm` 包和 `SHA256SUMS`**。发布页的「OpenWrt 原生安装包」表列出了完整文件名。IPK 与 APK 不能混装；APK 是 OpenWrt 的软件包，与 Android 安装包无关。
+
+例如，发布标签 `1.5.0` 的 x86_64 包名是 `msm_1.5.0-r1_x86_64.ipk` 或 `msm-1.5.0-r1_x86_64.apk`，LuCI 包名是 `luci-app-msm_1.5.0-r1_all.ipk` 或 `luci-app-msm-1.5.0-r1_all.apk`。Beta 标签 `beta-1.5.0` 的 IPK 包版本为 `1.5.0~beta-r1`，APK 包版本为 `1.5.0_beta-r1`，以遵循各包管理器的预发布版本排序；下载 URL 的目录仍使用原发布标签。这里的版本号仅用于说明命名，请以发布页实际文件为准。
+
+在路由器上创建一个空目录，例如 `/tmp/msm-install`，通过 SCP / SFTP 上传这三个文件。保留下载时的完整文件名，之后在该目录执行校验：
+
+```sh
+cd /tmp/msm-install
+: > selected.sha256
+for pkg in ./*.ipk ./*.apk; do
+    [ -f "$pkg" ] || continue
+    name="${pkg#./}"
+    awk -v name="$name" '$2 == name { print; found = 1 } END { if (!found) exit 1 }' SHA256SUMS >> selected.sha256 || exit 1
+done
+# 应当恰好找到两个包的校验记录，且两个文件都显示 OK。
+test "$(wc -l < selected.sha256)" -eq 2 && sha256sum -c selected.sha256
+```
+
+校验成功后，按实际包管理器安装。
+
+### opkg 固件（IPK）
+
+```sh
+cd /tmp/msm-install
+opkg update
+opkg install ./msm_*.ipk ./luci-app-msm_*.ipk
+```
+
+也可以通过 LuCI 的「系统 → 软件包 → 上传软件包」先安装 `msm`，再安装 `luci-app-msm`。安装本地文件和查询架构的语法见 [opkg 官方文档](https://openwrt.org/docs/guide-user/additional-software/opkg)。
+
+### apk 固件（APK）
+
+```sh
+cd /tmp/msm-install
+apk update
+apk add --allow-untrusted ./msm-*.apk ./luci-app-msm-*.apk
+```
+
+发布的 APK 是独立分发包，未使用 OpenWrt 官方软件源签名，因此在校验 SHA256 后用 `--allow-untrusted` 安装。这里的包使用 apk v3 格式，不能用于 Alpine 的旧版 apk v2。[apk 官方文档](https://openwrt.org/docs/guide-user/additional-software/apk)
+
+安装失败时先检查架构、剩余空间和固件软件源；不要跳过依赖检查。LuCI 插件需要固件提供的 LuCI 和 rpcd，依赖由包管理器解析安装。
+
+## 启动和初始化
+
+首次安装默认**不启动 MSM**。重新登录 LuCI，打开「服务 → MSM」：
+
+1. 确认 Web 端口，默认 `7777`。
+2. 确认数据目录，默认 `/etc/msm`。外接存储应先完成挂载；修改目录不会自动迁移原来的数据。
+3. 勾选启用，点击「保存并应用」。
+4. 点击「打开 MSM Web 界面」，完成 [首次使用](/zh/guide/first-use) 中的管理员初始化。
+
+也可以通过 SSH 启动：
+
+```sh
+uci set msm.main.enabled='1'
+uci set msm.main.port='7777'
+uci commit msm
+/etc/init.d/msm enable
+/etc/init.d/msm restart
+```
+
+默认 Web 地址是 `http://<路由器-LAN-IP>:7777`。OpenWrt 自带的 dnsmasq 通常使用 DNS 端口 `53`；初始化 DNS 服务时先选用空闲端口（例如 `1053`），验证成功后再配置 dnsmasq 转发或其他接入方式。安装包不会自动修改 DHCP、DNS、防火墙或静态路由。
+
+如果 MSM 就运行在这台 OpenWrt 上，不要照抄「MSM 位于另一台主机」的网关静态路由示例；按实际部署配置本机服务。
+
+## 服务管理和排错
+
+OpenWrt 原生包统一使用 procd 管理。下面的命令也适用于尚未包含新 CLI 服务管理适配的旧版 MSM：
+
+```sh
+# 状态、重启、停止
+/etc/init.d/msm status
+/etc/init.d/msm restart
+/etc/init.d/msm stop
+
+# 配置和系统日志
+uci show msm
+logread -e msm
+
+# procd 进程信息
+ubus call service list '{"name":"msm"}'
+```
+
+要持久停用，在 LuCI 取消启用并保存，或执行：
+
+```sh
+uci set msm.main.enabled='0'
+uci commit msm
+/etc/init.d/msm stop
+/etc/init.d/msm disable
+```
+
+首次创建默认数据目录时，程序日志放在 `/tmp/msm/logs`，以减少闪存写入；重启设备后这些日志会清空。配置和数据库仍保存在数据目录中。
+
+出现 Web 页面无法访问时，检查服务状态、配置端口是否被占用，以及实际 LAN 地址。修改数据目录后无法启动时，检查目录是否为绝对路径、存储是否已挂载且可写。LuCI 菜单未出现时，重新登录 LuCI 并确认 `luci-app-msm` 安装成功。
+
+## 更新、备份和卸载
+
+更新前，在 MSM 的 [备份恢复](/zh/guide/backup-restore) 页面导出配置，也可以在停服后复制整个数据目录。下载同一渠道的新 `msm` 与 `luci-app-msm` 包，校验后重复对应安装命令。升级保留 UCI 配置和应用数据；原先启用的服务在升级后恢复运行。
+
+OpenWrt 软件包安装的 MSM 应通过 **opkg / apk 更新**，不要再用通用 Linux 安装脚本覆盖程序和服务文件。
+
+卸载命令：
+
+```sh
+# opkg 固件
+opkg remove luci-app-msm msm
+
+# apk 固件（二选一，按实际包管理器执行）
+apk del luci-app-msm msm
+```
+
+卸载会停止服务，应用数据目录会保留。固件重刷、恢复出厂设置或外接存储变更前，应另外保存备份；自定义数据目录需要自行纳入固件升级备份。
+
+## 下一步
+
+- [首次使用](/zh/guide/first-use)
+- [DNS 服务管理](/zh/guide/mosdns)
+- [OpenWrt 接入独立 MSM 主机](/zh/guide/openwrt)

--- a/docs/zh/guide/install.md
+++ b/docs/zh/guide/install.md
@@ -13,7 +13,8 @@ MSM 是自托管管理平台。请仅用于自有或已获明确授权的设备�
 | --- | --- | --- |
 | Linux 服务器/虚拟机 | [Linux 安装](/zh/guide/install-linux) | 一键脚本 + systemd 服务 |
 | macOS 主机 | [macOS 安装](/zh/guide/install-macos) | CLI 安装或桌面版 |
-| Alpine/OpenWrt 类极简系统 | [Alpine 安装](/zh/guide/install-alpine) | musl + 手动服务管理 |
+| OpenWrt 路由器 | [OpenWrt 安装](/zh/guide/install-openwrt) | 原生 IPK / APK + LuCI 插件 + procd 服务 |
+| Alpine Linux | [Alpine 安装](/zh/guide/install-alpine) | musl + 手动服务管理 |
 | Docker 环境 | [Docker 安装](/zh/guide/docker) | 容器化部署 |
 
 ## 基本要求（通用）

--- a/docs/zh/guide/openwrt.md
+++ b/docs/zh/guide/openwrt.md
@@ -1,6 +1,8 @@
 # OpenWrt 配置指南
 
-适用于 OpenWrt/LEDE。以下以命令行（UCI）方式配置，适用于 LuCI 与 SSH 场景。
+本文用于 **OpenWrt / LEDE 接入另一台 MSM 主机**，以命令行（UCI）方式配置路由与 DNS。
+
+要把 MSM 直接安装到 OpenWrt 路由器上，请先阅读 [OpenWrt 原生包与 LuCI 插件安装](/zh/guide/install-openwrt)。
 
 ## 示例环境
 

--- a/test/openwrt-package-apk.test.cjs
+++ b/test/openwrt-package-apk.test.cjs
@@ -1,0 +1,76 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+// Opt-in because this exercises the real apk-tools 3 package manager in Docker.
+// Run: MSM_TEST_APK=1 node --test test/openwrt-package-apk.test.cjs
+test('APK v3 can be installed, upgraded and removed without losing configuration or data', {
+  skip: process.env.MSM_TEST_APK !== '1', timeout: 900_000,
+}, (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'msm-apk-integration-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const root = path.resolve(__dirname, '..');
+  const out = path.join(dir, 'out');
+  fs.mkdirSync(out);
+  function run(command, args, options = {}) {
+    const result = spawnSync(command, args, { encoding: 'utf8', timeout: 420_000, ...options });
+    assert.equal(result.status, 0, `${result.error || ''}\n${result.stdout}\n${result.stderr}`);
+    return result.stdout;
+  }
+  const archive = path.join(dir, 'release.tar.gz');
+  run(process.env.PYTHON || 'python3', ['-c', `import io, struct, tarfile, sys
+b = bytearray(128)
+b[:7] = b'\\x7fELF\\x02\\x01\\x01'
+struct.pack_into('<H', b, 18, 62)
+struct.pack_into('<Q', b, 32, 64)
+struct.pack_into('<HH', b, 54, 56, 1)
+struct.pack_into('<I', b, 64, 1)
+with tarfile.open(sys.argv[1], 'w:gz') as tar:
+ for name in ['msm', 'THIRD_PARTY_NOTICES.md', 'OSS_PROVENANCE.md', 'licenses/CADDY-APACHE-2.0.txt']:
+  contents = bytes(b) if name == 'msm' else b'license fixture\\n'
+  member = tarfile.TarInfo(name)
+  member.size = len(contents)
+  tar.addfile(member, io.BytesIO(contents))
+`, archive]);
+  const image = process.env.MSM_APK_IMAGE || 'alpine:3.23';
+  for (const version of ['1.5.0', '1.5.1']) {
+    run(process.env.PYTHON || 'python3', [path.join(root, '.github/openwrt/build-packages.py'), '--version', version,
+      '--target', 'linux-amd64', '--input', archive, '--output-dir', out, '--format', 'apk', '--apk-image', image]);
+  }
+  const packages = fs.readdirSync(out).filter((name) => name.endsWith('.apk'));
+  assert.equal(packages.length, 4);
+  for (const file of packages) assert.equal(fs.readFileSync(path.join(out, file)).subarray(0, 3).toString(), 'ADB');
+  // Package-manager file protection is tested with scripts disabled, so the
+  // Alpine test root does not need OpenWrt procd/uci. Shell lifecycle hooks have
+  // separate tests with an OpenWrt service harness in openwrt-package.test.cjs.
+  const script = `set -eu
+apk adbdump --allow-untrusted /work/luci-app-msm-1.5.0-r1_all.apk > /tmp/luci-metadata
+grep -q 'arch: noarch' /tmp/luci-metadata
+apk mkpkg --info name:openwrt-test-dependencies --info version:1-r1 --info arch:noarch --info license:MIT --info description:fixture --info 'provides:procd=1 uci=1 ca-bundle=1 luci-base=1' --output /tmp/dependencies.apk
+mkdir -p /tmp/root/etc/apk/protected_paths.d
+printf '+etc\\n' > /tmp/root/etc/apk/protected_paths.d/default.list
+apk --root /tmp/root --arch x86_64 --initdb --no-scripts --no-network --allow-untrusted add /tmp/dependencies.apk /work/msm-1.5.0-r1_x86_64.apk /work/luci-app-msm-1.5.0-r1_all.apk
+test "$(stat -c %u:%g /tmp/root/usr/bin/msm)" = 0:0
+test -x /tmp/root/usr/bin/msm
+test -x /tmp/root/etc/init.d/msm
+test -f /tmp/root/usr/share/luci/menu.d/luci-app-msm.json
+test -f /tmp/root/usr/share/doc/msm/licenses/CADDY-APACHE-2.0.txt
+printf '\\n# keep upgraded configuration\\n' >> /tmp/root/etc/config/msm
+mkdir -p /tmp/root/etc/msm/database
+printf 'keep database\\n' > /tmp/root/etc/msm/database/sentinel
+apk --root /tmp/root --arch x86_64 --no-scripts --no-network --allow-untrusted add /work/msm-1.5.1-r1_x86_64.apk /work/luci-app-msm-1.5.1-r1_all.apk
+grep -q 'keep upgraded configuration' /tmp/root/etc/config/msm
+test "$(cat /tmp/root/etc/msm/database/sentinel)" = 'keep database'
+apk --root /tmp/root --arch x86_64 --no-scripts --no-network del luci-app-msm msm
+test ! -e /tmp/root/usr/bin/msm
+grep -q 'keep upgraded configuration' /tmp/root/etc/config/msm
+test "$(cat /tmp/root/etc/msm/database/sentinel)" = 'keep database'
+printf 'APK v3 install/upgrade/remove preservation passed\\n'
+`;
+  fs.writeFileSync(path.join(out, 'test-apk.sh'), script);
+  const output = run('docker', ['run', '--rm', '--network', 'none', '-v', out + ':/work:ro', image, 'sh', '/work/test-apk.sh']);
+  assert.match(output, /APK v3 install\/upgrade\/remove preservation passed/);
+});

--- a/test/openwrt-package.test.cjs
+++ b/test/openwrt-package.test.cjs
@@ -1,0 +1,277 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const root = path.resolve(__dirname, '..');
+const builder = path.join(root, '.github/openwrt/build-packages.py');
+const templates = path.join(root, '.github/openwrt');
+const python = process.env.PYTHON || 'python3';
+const documents = ['THIRD_PARTY_NOTICES.md', 'OSS_PROVENANCE.md', 'licenses/CADDY-APACHE-2.0.txt'];
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, { encoding: 'utf8', timeout: 60_000, ...options });
+}
+function successful(result) {
+  assert.equal(result.status, 0, `${result.error || ''}\n${result.stdout}\n${result.stderr}`);
+  return result.stdout;
+}
+function scratch(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'msm-openwrt-test-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+function elf(target = 'linux-amd64', interpreter = false) {
+  const arch64 = !['linux-armv7', 'linux-armv6'].includes(target);
+  const binary = Buffer.alloc(arch64 ? 128 : 96);
+  binary.set([0x7f, 0x45, 0x4c, 0x46, arch64 ? 2 : 1, 1, 1]);
+  binary.writeUInt16LE(target === 'linux-amd64' ? 62 : arch64 ? 183 : 40, 18);
+  const offset = arch64 ? 64 : 52;
+  if (arch64) binary.writeBigUInt64LE(BigInt(offset), 32);
+  else binary.writeUInt32LE(offset, 28);
+  binary.writeUInt16LE(arch64 ? 56 : 32, arch64 ? 54 : 42);
+  binary.writeUInt16LE(1, arch64 ? 56 : 44);
+  binary.writeUInt32LE(interpreter ? 3 : 1, offset);
+  return binary;
+}
+function archive(dir, binary, options = {}) {
+  const file = path.join(dir, 'release.tar.gz');
+  const script = `import base64, io, json, tarfile, sys
+data = json.loads(sys.stdin.read())
+with tarfile.open(sys.argv[1], 'w:gz') as t:
+ for name, encoded, kind in data:
+  content = base64.b64decode(encoded)
+  info = tarfile.TarInfo(name)
+  info.size = len(content)
+  info.mode = 0o755 if name == 'msm' else 0o644
+  if kind == 'symlink':
+   info.type = tarfile.SYMTYPE
+   info.linkname = '/outside/msm'
+   info.size = 0
+  t.addfile(info, None if kind == 'symlink' else io.BytesIO(content))
+`;
+  const entries = [['msm', binary.toString('base64'), options.symlink ? 'symlink' : 'file']];
+  for (const doc of documents) {
+    if (!options.bare && doc !== options.missing) entries.push([doc, Buffer.from(`License fixture ${doc}\n`).toString('base64'), 'file']);
+  }
+  if (options.duplicate) entries.push(entries[0]);
+  entries.push(['../../not-extracted', Buffer.from('ignored').toString('base64'), 'file']);
+  successful(run(python, ['-c', script, file], { input: JSON.stringify(entries) }));
+  return file;
+}
+function build(dir, input, extra = [], options = {}) {
+  return run(python, [builder, '--version', 'v1.5.0', '--target', 'linux-amd64', '--input', input,
+    '--output-dir', path.join(dir, 'out'), '--format', 'ipk', ...extra], options);
+}
+function inspectIpk(file) {
+  const script = `import base64, io, json, tarfile, sys
+def unpack(t):
+ return {m.name.removeprefix('./'): {'mode': m.mode, 'uid': m.uid, 'gid': m.gid, 'data': base64.b64encode(t.extractfile(m).read()).decode() if m.isfile() else None} for m in t.getmembers()}
+with tarfile.open(sys.argv[1], 'r:gz') as t:
+ outer = unpack(t)
+ output = {'outer': outer}
+ for name in ['data', 'control']:
+  with tarfile.open(fileobj=io.BytesIO(base64.b64decode(outer[name + '.tar.gz']['data'])), mode='r:gz') as inner:
+   output[name] = unpack(inner)
+ print(json.dumps(output))
+`;
+  return JSON.parse(successful(run(python, ['-c', script, file])));
+}
+function text(entry) { return Buffer.from(entry.data, 'base64').toString(); }
+
+test('native IPK payload has correct metadata, original executable, notices and LuCI files', (t) => {
+  const dir = scratch(t);
+  const binary = elf();
+  successful(build(dir, archive(dir, binary)));
+  const msm = inspectIpk(path.join(dir, 'out/msm_1.5.0-r1_x86_64.ipk'));
+  assert.equal(text(msm.outer['debian-binary']), '2.0\n');
+  assert.deepEqual(Buffer.from(msm.data['usr/bin/msm'].data, 'base64'), binary);
+  assert.equal(msm.data['usr/bin/msm'].mode, 0o755);
+  assert.equal(msm.data['etc/init.d/msm'].mode, 0o755);
+  for (const value of Object.values(msm.data)) assert.deepEqual([value.uid, value.gid], [0, 0]);
+  assert.match(text(msm.control.control), /Package: msm\nVersion: 1.5.0-r1\nArchitecture: x86_64\n/);
+  assert.match(text(msm.control.control), /Depends: procd, uci, ca-bundle/);
+  assert.equal(text(msm.control.conffiles), '/etc/config/msm\n');
+  for (const doc of documents) assert.equal(text(msm.data[`usr/share/doc/msm/${doc}`]), `License fixture ${doc}\n`);
+  assert.match(text(msm.data['etc/config/msm']), /option enabled '0'/);
+  assert.match(text(msm.data['lib/upgrade/keep.d/msm']), /\/etc\/msm\//);
+  assert.ok(!Object.keys(msm.data).some((name) => name.startsWith('etc/msm/')));
+  assert.ok(!Object.keys(msm.data).some((name) => name.includes('not-extracted')));
+  const luci = inspectIpk(path.join(dir, 'out/luci-app-msm_1.5.0-r1_all.ipk'));
+  const menu = JSON.parse(text(luci.data['usr/share/luci/menu.d/luci-app-msm.json']));
+  assert.equal(menu['admin/services/msm'].action.path, 'msm');
+  const acl = JSON.parse(text(luci.data['usr/share/rpcd/acl.d/luci-app-msm.json']));
+  assert.deepEqual(acl['luci-app-msm'].write, { uci: ['msm'] });
+  assert.ok(luci.data['www/luci-static/resources/view/msm.js']);
+});
+
+test('IPKs are reproducible and beta versions preserve package-manager ordering syntax', (t) => {
+  const dir = scratch(t);
+  const input = archive(dir, elf());
+  successful(build(dir, input, ['--version', 'beta-1.5.0']));
+  const file = path.join(dir, 'out/msm_1.5.0~beta-r1_x86_64.ipk');
+  const first = fs.readFileSync(file);
+  successful(build(dir, input, ['--version', 'beta-1.5.0']));
+  assert.deepEqual(fs.readFileSync(file), first);
+  assert.match(text(inspectIpk(file).control.control), /Version: 1.5.0~beta-r1/);
+});
+
+test('all supported ARM architectures receive the matching original ELF', (t) => {
+  const dir = scratch(t);
+  const targets = {
+    'linux-arm64': ['aarch64_generic', 'aarch64_cortex-a53', 'aarch64_cortex-a72'],
+    'linux-armv7': ['arm_cortex-a7_neon-vfpv4', 'arm_cortex-a9_vfpv3-d16', 'arm_cortex-a9_neon', 'arm_cortex-a15_neon-vfpv4'],
+    'linux-armv6': ['arm_arm1176jzf-s_vfp'],
+  };
+  for (const [target, arches] of Object.entries(targets)) {
+    const binary = elf(target);
+    successful(build(dir, archive(dir, binary), ['--target', target]));
+    for (const arch of arches) {
+      const pkg = inspectIpk(path.join(dir, `out/msm_1.5.0-r1_${arch}.ipk`));
+      assert.match(text(pkg.control.control), new RegExp(`Architecture: ${arch}\\n`));
+      assert.deepEqual(Buffer.from(pkg.data['usr/bin/msm'].data, 'base64'), binary);
+    }
+  }
+});
+
+test('legacy stable archives without Caddy notices remain packageable', (t) => {
+  const dir = scratch(t);
+  const binary = elf();
+  successful(build(dir, archive(dir, binary, { bare: true })));
+  const pkg = inspectIpk(path.join(dir, 'out/msm_1.5.0-r1_x86_64.ipk'));
+  assert.deepEqual(Buffer.from(pkg.data['usr/bin/msm'].data, 'base64'), binary);
+  assert.ok(!Object.keys(pkg.data).some((name) => name.startsWith('usr/share/doc/msm/')));
+});
+
+test('builder rejects incompatible ELF, dynamic binaries, duplicate or linked payloads', (t) => {
+  const dir = scratch(t);
+  for (const [binary, options, expected] of [
+    [elf('linux-arm64'), {}, /ELF machine/],
+    [elf('linux-amd64', true), {}, /dynamically linked/],
+    [Buffer.from('#!\/bin\/sh\n'), {}, /Linux ELF/],
+    [elf(), { duplicate: true }, /one regular msm/],
+    [elf(), { symlink: true }, /one regular msm/],
+  ]) {
+    const result = build(dir, archive(dir, binary, options));
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, expected);
+  }
+  assert.notEqual(build(dir, archive(dir, elf()), ['--version', '1.5;bad']).status, 0);
+  assert.notEqual(build(dir, archive(dir, elf()), ['--arch', 'aarch64_generic']).status, 0);
+});
+
+function lifecycle(t, script, enabled, args = [], env = {}) {
+  const dir = scratch(t);
+  const log = path.join(dir, 'calls');
+  const init = path.join(dir, 'msm-init');
+  fs.writeFileSync(init, '#!/bin/sh\nprintf "%s\\n" "$*" >> "$CALLS"\n', { mode: 0o755 });
+  fs.writeFileSync(path.join(dir, 'uci'), '#!/bin/sh\nprintf "%s\\n" "$ENABLED"\n', { mode: 0o755 });
+  const executable = fs.readFileSync(path.join(templates, 'scripts', script), 'utf8').replaceAll('/etc/init.d/msm', init);
+  const result = run('sh', ['-s', '--', ...args], { input: executable, env: { ...process.env, PATH: dir + ':' + process.env.PATH, CALLS: log, ENABLED: enabled, ...env } });
+  successful(result);
+  return fs.existsSync(log) ? fs.readFileSync(log, 'utf8').trim().split('\n') : [];
+}
+test('install and upgrade register reload triggers even when disabled and respect image roots', (t) => {
+  assert.deepEqual(lifecycle(t, 'msm-postinst', '0'), ['enable', 'reload']);
+  assert.deepEqual(lifecycle(t, 'msm-postinst', '1'), ['enable', 'reload']);
+  assert.deepEqual(lifecycle(t, 'msm-postinst', '1', [], { IPKG_INSTROOT: '/staging' }), []);
+  assert.deepEqual(lifecycle(t, 'msm-postinst', '1', [], { IPKG_NO_SCRIPT: '1' }), []);
+  assert.deepEqual(lifecycle(t, 'msm-prerm', '1', ['upgrade']), ['stop']);
+  assert.deepEqual(lifecycle(t, 'msm-prerm', '1', ['remove']), ['stop', 'disable']);
+  assert.deepEqual(lifecycle(t, 'msm-pre-upgrade', '1'), ['stop']);
+});
+
+test('packaged LuCI lifecycle clears legacy and hashed menu caches before reloading rpcd', (t) => {
+  const dir = scratch(t);
+  successful(build(dir, archive(dir, elf())));
+  const pkg = inspectIpk(path.join(dir, 'out/luci-app-msm_1.5.0-r1_all.ipk'));
+  const caches = path.join(dir, 'cache');
+  const rpcd = path.join(dir, 'rpcd');
+  const calls = path.join(dir, 'calls');
+  fs.mkdirSync(caches);
+  fs.writeFileSync(rpcd, '#!/bin/sh\n[ ! -e "$CACHES/luci-indexcache.829a004f.json" ] || exit 1\nprintf "%s\\n" "$*" >> "$CALLS"\n', { mode: 0o755 });
+  const expected = ['luci-indexcache', 'luci-indexcache.829a004f.json', 'luci-indexcache.another.json', 'luci-modulecache'];
+  for (const phase of ['postinst', 'postrm']) {
+    for (const name of expected.slice(0, -1)) fs.writeFileSync(path.join(caches, name), 'stale menu');
+    fs.mkdirSync(path.join(caches, 'luci-modulecache'), { recursive: true });
+    fs.writeFileSync(path.join(caches, 'luci-modulecache/old.lua'), 'stale module');
+    fs.writeFileSync(path.join(caches, 'luci-indexcache-unrelated'), 'keep');
+    fs.writeFileSync(path.join(caches, 'other-application-cache'), 'keep');
+    const script = text(pkg.control[phase]).replaceAll('/tmp/', caches + '/').replaceAll('/etc/init.d/rpcd', rpcd);
+    const invoke = (extra = {}) => successful(run('sh', ['-s'], {
+      input: script, env: { ...process.env, CACHES: caches, CALLS: calls, ...extra },
+    }));
+    invoke({ IPKG_INSTROOT: '/image-root' });
+    invoke({ IPKG_NO_SCRIPT: '1' });
+    for (const name of expected) assert.ok(fs.existsSync(path.join(caches, name)), `${name} must survive image-root/script-disabled installs`);
+    invoke();
+    for (const name of expected) assert.equal(fs.existsSync(path.join(caches, name)), false, `${name} must be invalidated`);
+    assert.equal(fs.readFileSync(path.join(caches, 'luci-indexcache-unrelated'), 'utf8'), 'keep');
+    assert.equal(fs.readFileSync(path.join(caches, 'other-application-cache'), 'utf8'), 'keep');
+    invoke(); // Reinstall/removal remain safe when caches do not exist.
+  }
+  assert.equal(fs.readFileSync(calls, 'utf8'), 'reload\nreload\nreload\nreload\n');
+});
+
+test('procd receives quoted arguments, keeps existing data and uses volatile logs on first start', (t) => {
+  const dir = scratch(t);
+  const data = path.join(dir, 'data with spaces');
+  const template = fs.readFileSync(path.join(templates, 'files/msm/etc/init.d/msm'), 'utf8').replaceAll('/tmp/msm', path.join(dir, 'tmp/msm'));
+  function start(enabled = '1', config = data, port = '7777') {
+    return run('sh', ['-s'], {
+      env: { ...process.env, ENABLED: enabled, CONFIG: config, PORT: port },
+      input: `config_load() { :; }
+config_get_bool() { eval "$1=\\$ENABLED"; }
+config_get() { case "$3" in config_dir) eval "$1=\\$CONFIG";; port) eval "$1=\\$PORT";; esac; }
+logger() { :; }
+procd_open_instance() { :; }
+procd_close_instance() { :; }
+procd_set_param() { printf '<%s>' "$@"; printf '\\n'; }
+procd_add_reload_trigger() { printf '<trigger><%s>\\n' "$1"; }
+${template}
+start_service || exit $?
+service_triggers
+`,
+    });
+  }
+  assert.equal(successful(start('0')), '<trigger><msm>\n', 'disabled reload must register its trigger without opening a process instance');
+  assert.equal(fs.existsSync(data), false);
+  const output = successful(start());
+  assert.ok(output.includes(`<command></usr/bin/msm><serve><-c><${data}><-p><7777>`));
+  assert.equal(fs.readlinkSync(path.join(data, 'logs')), path.join(dir, 'tmp/msm/logs'));
+  fs.mkdirSync(path.join(data, 'database'));
+  fs.writeFileSync(path.join(data, 'database/sentinel'), 'persistent');
+  fs.unlinkSync(path.join(data, 'logs'));
+  fs.mkdirSync(path.join(data, 'logs'));
+  fs.writeFileSync(path.join(data, 'logs/existing'), 'keep me');
+  successful(start());
+  assert.equal(fs.readFileSync(path.join(data, 'logs/existing'), 'utf8'), 'keep me');
+  assert.equal(fs.readFileSync(path.join(data, 'database/sentinel'), 'utf8'), 'persistent');
+  for (const invalid of ['/', '//', 'relative', '/tmp/../root', '/../root']) assert.notEqual(start('1', invalid).status, 0);
+  for (const invalid of ['0', '65536', '7777; true']) assert.notEqual(start('1', data, invalid).status, 0);
+});
+
+test('LuCI validates the data directory and builds an IPv6-safe Web UI link', async () => {
+  const vm = require('node:vm');
+  const options = {};
+  const map = { section: () => ({ option: (type, name) => (options[name] = {}) }), render: async () => 'map' };
+  let pollCallback;
+  const source = fs.readFileSync(path.join(templates, 'files/luci-app-msm/www/luci-static/resources/view/msm.js'), 'utf8');
+  const view = vm.runInNewContext(`(function(){${source}})()`, {
+    view: { extend: (v) => v }, form: { Map: function() { return map; } },
+    rpc: { declare: (definition) => async () => definition.object === 'service' ? { msm: { instances: { main: { running: true } } } } : '7788' },
+    uci: { get: () => '7777' }, poll: { add: (callback, interval) => { assert.equal(interval, 5); pollCallback = callback; } },
+    window: { location: { hostname: '2001:db8::1' } }, _: (s) => s,
+    E: (tag, attributes = {}, children) => ({ tag, attributes, children, setAttribute(name, value) { this.attributes[name] = value; } }),
+  });
+  const rendered = await view.render([{}, {}]);
+  assert.equal(rendered.children[1].children.attributes.href, 'http://[2001:db8::1]:7777/');
+  assert.equal(rendered.children[0].children[1].textContent, 'Stopped');
+  await pollCallback();
+  assert.equal(rendered.children[1].children.attributes.href, 'http://[2001:db8::1]:7788/');
+  assert.equal(rendered.children[0].children[1].textContent, 'Running');
+  assert.equal(options.config_dir.validate('main', '/mnt/msm'), true);
+  for (const value of ['/', '////', '/tmp/../root', 'relative', '/tmp\nwrong']) assert.notEqual(options.config_dir.validate('main', value), true);
+});

--- a/test/release-workflow.test.cjs
+++ b/test/release-workflow.test.cjs
@@ -27,7 +27,8 @@ test('release workflows publish the merged single MSM runtime', () => {
   for (const workflow of workflows) {
     const source = fs.readFileSync(path.join(root, workflow), 'utf8')
 
-    assert.match(source, /tar -czf "dist\/msm-\$\{VERSION\}-\$\{\{ matrix\.target \}\}\.tar\.gz" -C dist \\\n\s+msm \\\n\s+THIRD_PARTY_NOTICES\.md/)
+    assert.match(source, /PACKAGE_FILES=\(msm\)/)
+    assert.match(source, /tar -czf "dist\/msm-\$\{VERSION\}-\$\{\{ matrix\.target \}\}\.tar\.gz" -C dist "\$\{PACKAGE_FILES\[@\]\}"/)
     assert.match(source, /tar -tzf "dist\/msm-\$\{VERSION\}-\$\{\{ matrix\.target \}\}\.tar\.gz" \| grep -Fx msm/)
     assert.match(source, /新版发布包不应再包含 msm-edge 可执行文件/)
     assert.doesNotMatch(source, /dist\/msm-edge|BUNDLED_EDGE|EDGE_ARCHS/)
@@ -155,4 +156,254 @@ test('summary preview validates inputs and uses the same runner without publishi
   assert.match(source, /path: \|\n\s+release-summary-preview\/summary\.md\n\s+release-summary-preview\/metadata\.json\n/)
   assert.doesNotMatch(source, /contents: write|pages:|id-token:|schedule:|workflow_run:|softprops\/|deploy-pages|gh release|git push|go build|npm run docs:build/)
   assert.equal((source.match(/uses: actions\/upload-artifact@/g) || []).length, 1)
+})
+
+test('OpenWrt packaging is mandatory and reuses each selected static Linux build', () => {
+  for (const workflow of workflows) {
+    const source = fs.readFileSync(path.join(root, workflow), 'utf8')
+    const openwrt = source.slice(source.indexOf('\n  openwrt:\n'), source.indexOf('\n  release:\n'))
+    const release = source.slice(source.indexOf('\n  release:\n'), source.indexOf('\n  docker:\n'))
+
+    assert.match(openwrt, /needs: \[prepare, build\]/)
+    assert.match(openwrt, /target: \[linux-amd64, linux-arm64, linux-armv7, linux-armv6\]/)
+    assert.match(openwrt, /name: msm-\$\{\{ needs\.prepare\.outputs\.version \}\}-\$\{\{ matrix\.target \}\}/)
+    assert.match(openwrt, /python3 \.github\/openwrt\/build-packages\.py[\s\S]*?--format all/)
+    assert.match(openwrt, /dist\/openwrt\/\*\.ipk\n\s+dist\/openwrt\/\*\.apk/)
+    assert.match(openwrt, /if-no-files-found: error/)
+    assert.doesNotMatch(openwrt, /continue-on-error|if-no-files-found: ignore/)
+    assert.match(release, /needs: \[prepare, build, openwrt\]/)
+    assert.match(release, /\$\{\{ steps\.release_assets\.outputs\.openwrt_section \}\}/)
+    assert.match(source, /CGO_ENABLED: \$\{\{ matrix\.goos == 'darwin' && '1' \|\| '0' \}\}/)
+    assert.match(source, /if \[ -f \.\.\/scripts\/prepare-embedded-frontend\.sh \]; then\n\s+bash \.\.\/scripts\/prepare-embedded-frontend\.sh\n\s+else/)
+  }
+})
+
+function workflowShellStep(source, name) {
+  const marker = `      - name: ${name}\n`
+  const start = source.indexOf(marker)
+  assert.notEqual(start, -1, `missing step ${name}`)
+  const remaining = source.slice(start + marker.length)
+  const step = remaining.split(/\n      - name:|\n  [a-z]/, 1)[0]
+  const run = step.split('        run: |\n')[1]
+  assert.ok(run, `missing run script in ${name}`)
+  return run.replace(/^          /gm, '')
+}
+
+function withReleaseFixture(workflow, callback) {
+  const os = require('node:os')
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'msm-release-openwrt-'))
+  const version = workflow.includes('-beta') ? 'beta-1.5.0' : '1.5.0'
+  const apkVersion = workflow.includes('-beta') ? '1.5.0_beta' : '1.5.0'
+  const ipkVersion = workflow.includes('-beta') ? '1.5.0~beta' : '1.5.0'
+  const names = [
+    `msm-${version}-linux-amd64.tar.gz`,
+    `msm-${version}-linux-arm64.tar.gz`,
+    `msm-${version}-linux-amd64-panabit.apx`,
+    `msm_${ipkVersion}-r1_x86_64.ipk`,
+    `msm-${apkVersion}-r1_x86_64.apk`,
+    `msm_${ipkVersion}-r1_aarch64_generic.ipk`,
+    `msm-${apkVersion}-r1_aarch64_generic.apk`,
+    `luci-app-msm_${ipkVersion}-r1_all.ipk`,
+    `luci-app-msm-${apkVersion}-r1_all.apk`,
+  ]
+  fs.mkdirSync(path.join(temp, 'dist', 'fixture'), { recursive: true })
+  for (const name of names) fs.writeFileSync(path.join(temp, 'dist', 'fixture', name), `${name}\n`)
+  fs.writeFileSync(path.join(temp, 'install_cn.sh'), '#!/bin/sh\n')
+  fs.writeFileSync(path.join(temp, 'install_beta_cn.sh'), '#!/bin/sh\n')
+  try {
+    callback({ temp, version, names })
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true })
+  }
+}
+
+function runWorkflowScript(source, name, { temp, version, target = 'linux-amd64' }) {
+  const { spawnSync } = require('node:child_process')
+  // GitHub uses Bash 5 and GNU coreutils. Supply their small missing pieces on macOS.
+  const compatibility = `
+if [ "\${BASH_VERSINFO[0]}" -lt 4 ]; then
+  mapfile() {
+    local map_name="$2" map_value map_quoted map_index=0
+    eval "$map_name=()"
+    while IFS= read -r map_value; do
+      printf -v map_quoted '%q' "$map_value"
+      eval "$map_name[$map_index]=$map_quoted"
+      map_index=$((map_index + 1))
+    done
+  }
+fi
+if ! command -v sha256sum >/dev/null 2>&1; then
+  sha256sum() { shasum -a 256 "$@"; }
+fi
+`
+  const script = workflowShellStep(source, name)
+    .replaceAll('${{ needs.prepare.outputs.version }}', version)
+    .replaceAll('${{ matrix.target }}', target)
+  assert.doesNotMatch(script, /\$\{\{/)
+  return spawnSync('bash', ['-c', compatibility + script], {
+    cwd: temp,
+    env: { ...process.env, GITHUB_OUTPUT: path.join(temp, 'step-output') },
+    encoding: 'utf8',
+  })
+}
+
+test('both release channels attach, checksum and mirror OpenWrt runtime and LuCI packages', () => {
+  const { createHash } = require('node:crypto')
+  for (const workflow of workflows) {
+    const source = fs.readFileSync(path.join(root, workflow), 'utf8')
+    withReleaseFixture(workflow, (fixture) => {
+      const collected = runWorkflowScript(source, '收集 Release 附件', fixture)
+      assert.equal(collected.status, 0, collected.stderr)
+      const outputs = fs.readFileSync(path.join(fixture.temp, 'step-output'), 'utf8')
+      const checksums = fs.readFileSync(path.join(fixture.temp, 'dist', 'SHA256SUMS'), 'utf8')
+      assert.match(outputs, /openwrt_section<<EOF/)
+      assert.match(outputs, /OpenWrt IPK\/APK、LuCI 插件/)
+      for (const name of fixture.names) {
+        assert.ok(outputs.includes(`dist/fixture/${name}\n`), `missing attachment ${name}`)
+        assert.ok(checksums.includes(`${createHash('sha256').update(`${name}\n`).digest('hex')}  ${name}\n`))
+        if (/\.(?:ipk|apk)$/.test(name)) {
+          assert.ok(outputs.includes(`/releases/download/${fixture.version}/${name}`), `missing download link ${name}`)
+        }
+      }
+      const uploaded = runWorkflowScript(source, '准备上传文件', fixture)
+      assert.equal(uploaded.status, 0, uploaded.stderr)
+      assert.deepEqual(fs.readdirSync(path.join(fixture.temp, 'upload', fixture.version)).sort(),
+        [...fixture.names, 'SHA256SUMS'].sort())
+      assert.equal(fs.readFileSync(path.join(fixture.temp, 'upload', fixture.version, 'SHA256SUMS'), 'utf8'), checksums)
+    })
+  }
+})
+
+test('release refuses a missing OpenWrt artifact and still lists OpenWrt when optional Panabit is absent', () => {
+  for (const workflow of workflows) {
+    const source = fs.readFileSync(path.join(root, workflow), 'utf8')
+    withReleaseFixture(workflow, (fixture) => {
+      for (const name of fixture.names.filter((name) => name.endsWith('.apx'))) {
+        fs.unlinkSync(path.join(fixture.temp, 'dist', 'fixture', name))
+      }
+      const withoutPanabit = runWorkflowScript(source, '收集 Release 附件', fixture)
+      assert.equal(withoutPanabit.status, 0, withoutPanabit.stderr)
+      const outputs = fs.readFileSync(path.join(fixture.temp, 'step-output'), 'utf8')
+      assert.match(outputs, /openwrt_section<<EOF/)
+      assert.match(outputs, /download_note=.*OpenWrt IPK\/APK、LuCI 插件/)
+      for (const name of fixture.names.filter((name) => /\.(?:ipk|apk)$/.test(name))) {
+        fs.unlinkSync(path.join(fixture.temp, 'dist', 'fixture', name))
+      }
+      const missingOpenwrt = runWorkflowScript(source, '收集 Release 附件', fixture)
+      assert.notEqual(missingOpenwrt.status, 0)
+      assert.match(missingOpenwrt.stderr, /缺少 OpenWrt 安装包/)
+    })
+  }
+})
+
+test('OpenWrt builds reject source revisions without a successful runtime compatibility check', () => {
+  for (const workflow of workflows) {
+    const source = fs.readFileSync(path.join(root, workflow), 'utf8')
+    const guard = source.indexOf('      - name: 验证 OpenWrt 运行时兼容性')
+    assert.ok(guard > source.indexOf('\n  build:\n'))
+    assert.ok(guard < source.indexOf('      - name: 编译 MSM（发布加固版）'))
+    assert.match(source.slice(guard, source.indexOf('      - name: Checkout 当前仓库（msm-wiki）用于派网 APX 模板')),
+      /if: matrix\.target == 'linux-amd64' \|\| matrix\.target == 'linux-arm64' \|\| matrix\.target == 'linux-armv7' \|\| matrix\.target == 'linux-armv6'/)
+    withReleaseFixture(workflow, (fixture) => {
+      const missing = runWorkflowScript(source, '验证 OpenWrt 运行时兼容性', fixture)
+      assert.notEqual(missing.status, 0)
+      assert.match(missing.stderr, /源码缺少 OpenWrt 兼容性检查/)
+      fs.mkdirSync(path.join(fixture.temp, 'scripts'))
+      const guardScript = path.join(fixture.temp, 'scripts', 'check-openwrt-compatibility.sh')
+      fs.writeFileSync(guardScript, '#!/bin/sh\nexit 14\n')
+      assert.equal(runWorkflowScript(source, '验证 OpenWrt 运行时兼容性', fixture).status, 14)
+      fs.writeFileSync(guardScript, '#!/bin/sh\nexit 0\n')
+      assert.equal(runWorkflowScript(source, '验证 OpenWrt 运行时兼容性', fixture).status, 0)
+    })
+  }
+})
+
+test('CLI packaging supports pre-Caddy sources and requires complete notices for Caddy builds', () => {
+  const { execFileSync } = require('node:child_process')
+  const notices = new Map([
+    ['THIRD_PARTY_NOTICES.md', 'THIRD_PARTY_NOTICES.md'],
+    ['docs/OSS_PROVENANCE.md', 'OSS_PROVENANCE.md'],
+    ['licenses/CADDY-APACHE-2.0.txt', 'licenses/CADDY-APACHE-2.0.txt'],
+  ])
+  for (const workflow of workflows) {
+    const source = fs.readFileSync(path.join(root, workflow), 'utf8')
+    for (const scenario of ['legacy', 'optional notice', 'caddy', 'caddy single-line', ...notices.keys()]) {
+      withReleaseFixture(workflow, (fixture) => {
+        fs.mkdirSync(path.join(fixture.temp, 'scripts'))
+        fs.mkdirSync(path.join(fixture.temp, 'backend'))
+        fs.writeFileSync(path.join(fixture.temp, 'scripts', 'build-release-msm.sh'), '#!/bin/sh\nprintf "MSM fixture\\n" > "$1"\n')
+        fs.writeFileSync(path.join(fixture.temp, 'scripts', 'embed-executable-sha256.sh'), '#!/bin/sh\nexit 0\n')
+        fs.writeFileSync(path.join(fixture.temp, 'scripts', 'verify-executable-sha256.sh'), '#!/bin/sh\ntest -s "$1"\n')
+        const hasCaddy = scenario !== 'legacy' && scenario !== 'optional notice'
+        fs.writeFileSync(path.join(fixture.temp, 'backend', 'go.mod'),
+          `module msm\n${hasCaddy ? (scenario === 'caddy single-line' ? 'require github.com/caddyserver/caddy/v2 v2.11.4\n' : 'require (\n\tgithub.com/caddyserver/caddy/v2 v2.11.4\n)\n') : ''}`)
+        const included = []
+        for (const [notice, destination] of notices) {
+          if (scenario === 'legacy' || scenario === notice) continue
+          if (scenario === 'optional notice' && notice !== 'THIRD_PARTY_NOTICES.md') continue
+          fs.mkdirSync(path.dirname(path.join(fixture.temp, notice)), { recursive: true })
+          fs.writeFileSync(path.join(fixture.temp, notice), `${notice} original contents\n`)
+          included.push(destination)
+        }
+        const packaged = runWorkflowScript(source, '编译 MSM（发布加固版）', fixture)
+        if (notices.has(scenario)) {
+          assert.notEqual(packaged.status, 0, `Caddy build must reject missing ${scenario}`)
+          assert.ok(packaged.stderr.includes(`含 Caddy 的发布版本缺少开源声明: ${scenario}`), packaged.stderr)
+          return
+        }
+        assert.equal(packaged.status, 0, `${scenario}: ${packaged.stderr}`)
+        const archive = path.join(fixture.temp, 'dist', `msm-${fixture.version}-linux-amd64.tar.gz`)
+        const entries = execFileSync('tar', ['-tzf', archive], { encoding: 'utf8' }).trim().split('\n')
+        assert.deepEqual(entries, ['msm', ...included], `${workflow}: ${scenario}`)
+        for (const [notice, destination] of notices) {
+          if (!included.includes(destination)) continue
+          assert.equal(execFileSync('tar', ['-xOzf', archive, destination], { encoding: 'utf8' }), `${notice} original contents\n`)
+        }
+      })
+    }
+  }
+})
+
+test('both release channels require real APK lifecycle checks in the amd64 OpenWrt job', () => {
+  for (const workflow of workflows) {
+    const source = fs.readFileSync(path.join(root, workflow), 'utf8')
+    const openwrt = source.slice(source.indexOf('\n  openwrt:\n'), source.indexOf('\n  release:\n'))
+    assert.match(openwrt, /name: Setup Node\.js for OpenWrt checks\n\s+if: matrix\.target == 'linux-amd64'\n\s+uses: actions\/setup-node@v4\n\s+with:\n\s+node-version: '22'/)
+    assert.match(openwrt, /name: 验证真实 APK 安装、升级和卸载\n\s+if: matrix\.target == 'linux-amd64'\n\s+env:\n\s+MSM_TEST_APK: '1'\n\s+run: node --test test\/openwrt-package\*\.test\.cjs/)
+    assert.ok(openwrt.indexOf('name: 验证真实 APK 安装、升级和卸载') < openwrt.indexOf('name: 上传 OpenWrt IPK / APK 产物'))
+    assert.doesNotMatch(openwrt, /continue-on-error/)
+  }
+})
+
+test('OpenWrt pull request checks are path-scoped, read-only and exercise real APK packages', () => {
+  const source = fs.readFileSync(path.join(root, '.github/workflows/openwrt-check.yml'), 'utf8')
+  assert.match(source, /pull_request:\n\s+paths:/)
+  assert.match(source, /push:\n\s+branches: \[codex\/openwrt-packages\]\n\s+paths:/)
+  const triggers = source.slice(source.indexOf('\non:\n'), source.indexOf('\npermissions:\n'))
+  for (const watchedPath of [
+    '.github/openwrt/**',
+    '.github/workflows/openwrt-check.yml',
+    ...workflows,
+    'test/openwrt-package*.test.cjs',
+    'test/release-workflow.test.cjs',
+  ]) {
+    assert.equal(triggers.split(`'${watchedPath}'`).length - 1, 2, `${watchedPath} must trigger pull requests and branch pushes`)
+  }
+  assert.match(source, /permissions:\n\s+contents: read/)
+  assert.match(source, /persist-credentials: false/)
+  assert.match(source, /node-version: '22'/)
+  assert.match(source, /actionlint_1\.7\.12_linux_amd64\.tar\.gz/)
+  assert.match(source, /sha256sum -c -/)
+  assert.match(source, /MSM_TEST_APK: '1'\n\s+run: node --test test\/openwrt-package\*\.test\.cjs test\/release-workflow\.test\.cjs/)
+  assert.doesNotMatch(source, /pull_request_target|secrets\.|contents: write|npm ci|continue-on-error|git push|gh release|upload-artifact|deploy-pages/)
+})
+
+
+test('forced releases update existing assets and fail if any attachment cannot be published', () => {
+  for (const workflow of workflows) {
+    const source = fs.readFileSync(path.join(root, workflow), 'utf8')
+    assert.match(source, /if \[ "\$\{FORCE_UPDATE\}" != "true" \]; then[\s\S]*?echo "skip=true"/)
+    assert.match(source, /uses: ncipollo\/release-action@v1[\s\S]*?allowUpdates: true\n\s+replacesArtifacts: true\n\s+artifactErrorsFailBuild: true\n\s+artifacts: \$\{\{ steps\.release_assets\.outputs\.paths \}\}/)
+    assert.doesNotMatch(source, /removeArtifacts: true|skipIfReleaseExists: true|updateOnlyUnreleased: true/)
+  }
 })


### PR DESCRIPTION
现有 Release 缺少 OpenWrt 原生包，普通 Linux 安装流程也无法提供 LuCI 管理入口。此变更为 stable/beta 发布增加 IPK、APK v3 和 luci-app-msm，覆盖 x86_64、ARM64、ARMv7、ARMv6，共 20 个 OpenWrt 附件，并纳入校验和及镜像上传。

The release pipeline now creates native OpenWrt packages and a LuCI service page from the existing static Linux artifacts. Runtime compatibility is required before packaging, package upload errors fail the release, and source binaries retain their integrity metadata. Installation defaults to disabled while registering procd reload triggers; upgrades preserve UCI settings and application data.

验证 / Validation:
- 包格式、ELF 静态链接、安装钩子、配置保留、LuCI 缓存与发布收集回归测试通过；独立 CI 开启真实 APK v3 安装/升级/卸载测试。
- 官方 OpenWrt 24.10.8 x86_64 rootfs 完成 IPK 安装、HTTP 初始化、升级、卸载验证。
- ARM64 OpenWrt 实机完成 APK 安装/升级、LuCI 页面与启用、procd 管理及 HTTP 初始化验证；原有网络配置、路由、规则和防火墙表对比未变。
- 文档构建与 actionlint 通过。

运行时适配已进入 MSM dev，并通过 msm9527/msm#87 回移到 stable main。首次使用和架构选择说明见新增 OpenWrt 安装文档。
