### PR TITLE
修复 OpenWrt IPK 发布文件名 / Fix OpenWrt IPK release asset names

### DIFF
--- a/.github/openwrt/README.md
+++ b/.github/openwrt/README.md
@@ -37,8 +37,12 @@ built once by the amd64 job, or for another target with `--with-luci`. IPK uses
 both formats. APK filenames include the architecture so release matrix outputs
 cannot overwrite one another.
 
-Stable versions map to `1.5.0-r1`. `beta-1.5.0` maps to `1.5.0~beta-r1` for opkg
-and `1.5.0_beta-r1` for apk, so a stable package supersedes its matching beta.
+Stable versions map to `1.5.0-r1`. `beta-1.5.0` maps to package metadata version
+`1.5.0~beta-r1` for opkg and `1.5.0_beta-r1` for apk, so a stable package supersedes
+its matching beta. IPK **filenames** use an underscore instead of a tilde, such as
+`msm_1.5.0_beta-r1_x86_64.ipk`; the control file still contains
+`Version: 1.5.0~beta-r1`. This prevents GitHub release asset-name normalization
+from changing filenames and invalidating `SHA256SUMS` entries. APK names are unchanged.
 `--release` changes the package revision. `SOURCE_DATE_EPOCH` defaults to zero.
 
 The UCI section is `msm.main` (type `msm`): `enabled=0`,

--- a/.github/openwrt/build-packages.py
+++ b/.github/openwrt/build-packages.py
@@ -173,7 +173,10 @@ def build_ipk(root, name, version, arch, output, epoch):
     if name == "msm":
         controls.append(("conffiles", b"/etc/config/msm\n", 0o644, False))
     package = tar_gz([("debian-binary", b"2.0\n", 0o644, False), ("data.tar.gz", data, 0o644, False), ("control.tar.gz", tar_gz(controls, epoch), 0o644, False)], epoch)
-    path = output / (name + "_" + version + "_" + arch + ".ipk")
+    # GitHub normalizes '~' in release asset names. Keep it only in control
+    # metadata so prerelease ordering works and checksum filenames stay valid.
+    filename_version = version.replace("~", "_")
+    path = output / (name + "_" + filename_version + "_" + arch + ".ipk")
     path.write_bytes(package)
     return path
 

--- a/docs/zh/guide/install-openwrt.md
+++ b/docs/zh/guide/install-openwrt.md
@@ -43,7 +43,7 @@ free -m
 
 在同一个发布版本中下载三个文件：**一个匹配架构的 `msm` 包、一个同格式的 `luci-app-msm` 包和 `SHA256SUMS`**。发布页的「OpenWrt 原生安装包」表列出了完整文件名。IPK 与 APK 不能混装；APK 是 OpenWrt 的软件包，与 Android 安装包无关。
 
-例如，发布标签 `1.5.0` 的 x86_64 包名是 `msm_1.5.0-r1_x86_64.ipk` 或 `msm-1.5.0-r1_x86_64.apk`，LuCI 包名是 `luci-app-msm_1.5.0-r1_all.ipk` 或 `luci-app-msm-1.5.0-r1_all.apk`。Beta 标签 `beta-1.5.0` 的 IPK 包版本为 `1.5.0~beta-r1`，APK 包版本为 `1.5.0_beta-r1`，以遵循各包管理器的预发布版本排序；下载 URL 的目录仍使用原发布标签。这里的版本号仅用于说明命名，请以发布页实际文件为准。
+例如，发布标签 `1.5.0` 的 x86_64 包名是 `msm_1.5.0-r1_x86_64.ipk` 或 `msm-1.5.0-r1_x86_64.apk`，LuCI 包名是 `luci-app-msm_1.5.0-r1_all.ipk` 或 `luci-app-msm-1.5.0-r1_all.apk`。Beta 标签 `beta-1.5.0` 的文件名使用 `1.5.0_beta-r1`，例如 `msm_1.5.0_beta-r1_x86_64.ipk`，避免下载服务器改写特殊字符。IPK 内部版本仍为 `1.5.0~beta-r1`，APK 内部版本为 `1.5.0_beta-r1`，以遵循各包管理器的预发布版本排序；下载 URL 的目录仍使用原发布标签。这里的版本号仅用于说明命名，请以发布页实际文件为准。
 
 在路由器上创建一个空目录，例如 `/tmp/msm-install`，通过 SCP / SFTP 上传这三个文件。保留下载时的完整文件名，之后在该目录执行校验：
 

--- a/test/openwrt-package.test.cjs
+++ b/test/openwrt-package.test.cjs
@@ -107,15 +107,22 @@ test('native IPK payload has correct metadata, original executable, notices and 
   assert.ok(luci.data['www/luci-static/resources/view/msm.js']);
 });
 
-test('IPKs are reproducible and beta versions preserve package-manager ordering syntax', (t) => {
+test('IPKs use release-safe filenames while preserving beta ordering metadata and reproducibility', (t) => {
   const dir = scratch(t);
   const input = archive(dir, elf());
   successful(build(dir, input, ['--version', 'beta-1.5.0']));
-  const file = path.join(dir, 'out/msm_1.5.0~beta-r1_x86_64.ipk');
+  const file = path.join(dir, 'out/msm_1.5.0_beta-r1_x86_64.ipk');
   const first = fs.readFileSync(file);
   successful(build(dir, input, ['--version', 'beta-1.5.0']));
   assert.deepEqual(fs.readFileSync(file), first);
   assert.match(text(inspectIpk(file).control.control), /Version: 1.5.0~beta-r1/);
+  const filenames = fs.readdirSync(path.join(dir, 'out'));
+  assert.deepEqual(filenames.sort(), ['luci-app-msm_1.5.0_beta-r1_all.ipk', 'msm_1.5.0_beta-r1_x86_64.ipk']);
+  for (const filename of filenames) {
+    assert.ok(!filename.includes('~'), 'release asset filenames must not need GitHub normalization');
+    assert.match(filename, /^[A-Za-z0-9_.-]+$/);
+    assert.match(text(inspectIpk(path.join(dir, 'out', filename)).control.control), /Version: 1.5.0~beta-r1/);
+  }
 });
 
 test('all supported ARM architectures receive the matching original ELF', (t) => {

--- a/test/release-workflow.test.cjs
+++ b/test/release-workflow.test.cjs
@@ -194,7 +194,7 @@ function withReleaseFixture(workflow, callback) {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'msm-release-openwrt-'))
   const version = workflow.includes('-beta') ? 'beta-1.5.0' : '1.5.0'
   const apkVersion = workflow.includes('-beta') ? '1.5.0_beta' : '1.5.0'
-  const ipkVersion = workflow.includes('-beta') ? '1.5.0~beta' : '1.5.0'
+  const ipkVersion = workflow.includes('-beta') ? '1.5.0_beta' : '1.5.0'
   const names = [
     `msm-${version}-linux-amd64.tar.gz`,
     `msm-${version}-linux-arm64.tar.gz`,


### PR DESCRIPTION
GitHub 会改写 IPK 文件名中的 `~`，导致发布后的资产名称与 `SHA256SUMS` 不一致。现在 IPK 文件名使用 `1.5.0_beta-r1`，包内 `Version` 继续使用 `1.5.0~beta-r1`，保持 opkg 的预发布版本排序。同步更新安装文档与发布工作流测试示例。

验证：
- `node --test test/openwrt-package.test.cjs`：9 项通过，验证真实 IPK 文件名、control 版本、可复现性和生命周期。
- `node --test test/release-workflow.test.cjs`：19 项通过。
