### PR TITLE
修复 OpenWrt Beta 镜像文件名 / Repair OpenWrt beta mirror filenames

### DIFF
--- a/.github/openwrt/README.md
+++ b/.github/openwrt/README.md
@@ -72,3 +72,20 @@ Format references:
 - [OpenWrt package generation and APK metadata](https://github.com/openwrt/openwrt/blob/main/include/package-pack.mk)
 - [Upstream apk mkpkg](https://gitlab.alpinelinux.org/alpine/apk-tools/-/blob/master/doc/apk-mkpkg.8.scd)
 - [OpenWrt apk usage](https://openwrt.org/docs/guide-user/additional-software/apk)
+
+## Repairing an existing Beta mirror
+
+After correcting GitHub IPK asset names and its `SHA256SUMS`, the manual
+`openwrt-repair-mirror.yml` workflow can repair an already uploaded mirror without
+rebuilding or replacing package contents. Supply the numeric Beta tag and its
+original daily Beta run ID. That run must have completed its mirror upload;
+its exact `msm-<tag>-checksums` artifact must match every published file hash after
+normalizing only the old IPK filenames.
+
+The workflow validates the complete mirror before making changes, copies verified
+legacy IPKs to canonical names, keeps IPKs and the manifest readable with mode
+0644, verifies the complete manifest, and atomically replaces `SHA256SUMS` before
+removing verified old aliases. Existing canonical files are checked on reruns.
+It uses the same `DEPLOY_SERVERS` configuration as the daily publisher and changes
+only `<target>/beta/<tag>`. The remote mirror requires Bash and GNU coreutils.
+Local mirror tests on macOS use GNU `gmv` from `brew install coreutils`.

--- a/.github/openwrt/prepare-mirror-repair.cjs
+++ b/.github/openwrt/prepare-mirror-repair.cjs
@@ -1,0 +1,103 @@
+const fs = require('node:fs');
+const crypto = require('node:crypto');
+
+const ARCHES = ['x86_64', 'aarch64_generic', 'aarch64_cortex-a53', 'aarch64_cortex-a72', 'arm_cortex-a7_neon-vfpv4', 'arm_cortex-a9_vfpv3-d16', 'arm_cortex-a9_neon', 'arm_cortex-a15_neon-vfpv4', 'arm_arm1176jzf-s_vfp'];
+const digest = value => `sha256:${crypto.createHash('sha256').update(value).digest('hex')}`;
+const quote = value => `'${value.replaceAll("'", "'\\''")}'`;
+
+function prepareMirrorRepair(release, checksums, tag, sourceChecksums) {
+  if (!/^beta-\d+\.\d+\.\d+$/.test(tag) || release.tag_name !== tag || release.draft || !release.prerelease) {
+    throw new Error('Expected the requested published numeric beta tag');
+  }
+  const version = `${tag.slice(5)}_beta-r1`;
+  const ipks = [...ARCHES.map(arch => `msm_${version}_${arch}.ipk`), `luci-app-msm_${version}_all.ipk`];
+  const apks = [...ARCHES.map(arch => `msm-${version}_${arch}.apk`), `luci-app-msm-${version}_all.apk`];
+  const expected = new Set([...ipks, ...apks]);
+  const assets = new Map(release.assets.map(asset => [asset.name, asset]));
+  if (assets.size !== release.assets.length) throw new Error('Duplicate release asset');
+  const openwrt = release.assets.filter(asset => /\.(ipk|apk)$/.test(asset.name));
+  if (openwrt.length !== 20 || openwrt.some(asset => !expected.has(asset.name))) {
+    throw new Error('Release must contain exactly the 20 canonical OpenWrt assets');
+  }
+  if (assets.get('SHA256SUMS')?.digest !== digest(checksums)) throw new Error('SHA256SUMS does not match its published digest');
+  if (checksums !== `${checksums.trimEnd()}\n`) throw new Error('Checksum manifest must use one final newline');
+  const sums = new Map();
+  for (const line of checksums.trimEnd().split('\n')) {
+    const match = /^([a-f0-9]{64})\s+\*?([A-Za-z0-9][A-Za-z0-9._+-]*)$/.exec(line);
+    if (!match || sums.has(match[2])) throw new Error('Unsafe or duplicate checksum filename');
+    const [, hash, name] = match;
+    const asset = assets.get(name);
+    if (!asset || asset.state !== 'uploaded' || asset.digest !== `sha256:${hash}`) {
+      throw new Error(`Published asset checksum mismatch: ${name}`);
+    }
+    sums.set(name, hash);
+  }
+  if ([...expected].some(name => !sums.has(name))) throw new Error('Missing OpenWrt checksum');
+  if (typeof sourceChecksums !== 'string') throw new Error('Original run checksum artifact is required');
+  const original = new Map();
+  for (const line of sourceChecksums.trimEnd().split('\n')) {
+    const match = /^([a-f0-9]{64})\s+\*?([A-Za-z0-9][A-Za-z0-9._+~-]*)$/.exec(line);
+    if (!match) throw new Error('Invalid original run checksum');
+    const name = match[2].endsWith('.ipk') ? match[2].replace(/(?:~|\.)beta-r1_/, '_beta-r1_') : match[2];
+    if (original.has(name)) throw new Error('Duplicate original run checksum');
+    original.set(name, match[1]);
+  }
+  if (original.size !== sums.size || [...sums].some(([name, hash]) => original.get(name) !== hash)) {
+    throw new Error('Original run tag/content does not match the published release');
+  }
+  const script = [
+    '#!/usr/bin/env bash', 'set -euo pipefail', 'cd -- "$1"',
+    'if [ ! -f SHA256SUMS ] || [ -L SHA256SUMS ]; then echo "Invalid mirror SHA256SUMS" >&2; exit 1; fi',
+    'check_file() {',
+    '  if [ ! -f "$2" ] || [ -L "$2" ]; then echo "Invalid mirror file: $2" >&2; exit 1; fi',
+    '  printf "%s  %s\\n" "$1" "$2" | sha256sum -c -',
+    '}',
+  ];
+  // Validate the complete mirror and every legacy alias before any mutation.
+  for (const name of ipks) {
+    const hash = sums.get(name);
+    const aliases = [name.replace('_beta-', '~beta-'), name.replace('_beta-', '.beta-')];
+    script.push(`if [ -e ${quote(name)} ] || [ -L ${quote(name)} ]; then`,
+      `  check_file ${quote(hash)} ${quote(name)}`, 'else',
+      `  if [ -f ${quote(aliases[0])} ]; then source=${quote(aliases[0])}; else source=${quote(aliases[1])}; fi`,
+      `  check_file ${quote(hash)} "$source"`, 'fi');
+    for (const alias of aliases) script.push(`if [ -e ${quote(alias)} ] || [ -L ${quote(alias)} ]; then`, `  check_file ${quote(hash)} ${quote(alias)}`, 'fi');
+  }
+  for (const [name, hash] of sums) if (!ipks.includes(name)) script.push(`check_file ${quote(hash)} ${quote(name)}`);
+  script.push('temporary="$(mktemp .msm-openwrt-repair.XXXXXX)"', 'trap \'rm -f -- "$temporary"\' EXIT');
+  for (const name of ipks) {
+    const hash = sums.get(name);
+    const old = name.replace('_beta-', '~beta-');
+    const normalized = name.replace('_beta-', '.beta-');
+    script.push(
+      `if [ -e ${quote(name)} ] || [ -L ${quote(name)} ]; then`,
+      `  check_file ${quote(hash)} ${quote(name)}`,
+      'else',
+      `  if [ -f ${quote(old)} ]; then source=${quote(old)}; else source=${quote(normalized)}; fi`,
+      `  check_file ${quote(hash)} "$source"`,
+      '  cp -- "$source" "$temporary"',
+      `  check_file ${quote(hash)} "$temporary"`,
+      '  chmod 0644 "$temporary"',
+      `  mv -T -- "$temporary" ${quote(name)}`,
+      'fi',
+      `chmod 0644 ${quote(name)}`,
+    );
+  }
+  // Verify every existing platform against the complete, unchanged hash list
+  // before atomically installing the renamed checksum manifest.
+  for (const [name, hash] of sums) script.push(`check_file ${quote(hash)} ${quote(name)}`);
+  script.push('cat > "$temporary" <<\'MSM_OPENWRT_CHECKSUMS\'', checksums.trimEnd(), 'MSM_OPENWRT_CHECKSUMS', `check_file ${quote(digest(checksums).slice(7))} "$temporary"`, 'chmod 0644 "$temporary"', 'mv -T -- "$temporary" SHA256SUMS');
+  for (const name of ipks) {
+    for (const old of [name.replace('_beta-', '~beta-'), name.replace('_beta-', '.beta-')]) {
+      script.push(`if [ -e ${quote(old)} ] || [ -L ${quote(old)} ]; then`, `  check_file ${quote(sums.get(name))} ${quote(old)}`, `  rm -- ${quote(old)}`, 'fi');
+    }
+  }
+  script.push('echo "OpenWrt mirror filenames and complete SHA256SUMS verified"', '');
+  return script.join('\n');
+}
+
+module.exports = { prepareMirrorRepair };
+if (require.main === module) {
+  const [, , tag, releaseFile, checksumsFile, sourceChecksumsFile, outputFile] = process.argv;
+  fs.writeFileSync(outputFile, prepareMirrorRepair(JSON.parse(fs.readFileSync(releaseFile, 'utf8')), fs.readFileSync(checksumsFile, 'utf8'), tag, fs.readFileSync(sourceChecksumsFile, 'utf8')));
+}

--- a/.github/workflows/openwrt-check.yml
+++ b/.github/workflows/openwrt-check.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/openwrt/**'
       - '.github/workflows/openwrt-check.yml'
+      - '.github/workflows/openwrt-repair-mirror.yml'
       - '.github/workflows/daily-build-msm.yml'
       - '.github/workflows/daily-build-msm-beta.yml'
       - 'test/openwrt-package*.test.cjs'
@@ -14,6 +15,7 @@ on:
     paths:
       - '.github/openwrt/**'
       - '.github/workflows/openwrt-check.yml'
+      - '.github/workflows/openwrt-repair-mirror.yml'
       - '.github/workflows/daily-build-msm.yml'
       - '.github/workflows/daily-build-msm-beta.yml'
       - 'test/openwrt-package*.test.cjs'
@@ -57,6 +59,7 @@ jobs:
           tar -xzf "${ACTIONLINT_ARCHIVE}" -C "${RUNNER_TEMP}" actionlint
           "${RUNNER_TEMP}/actionlint" -shellcheck= \
             .github/workflows/openwrt-check.yml \
+            .github/workflows/openwrt-repair-mirror.yml \
             .github/workflows/daily-build-msm.yml \
             .github/workflows/daily-build-msm-beta.yml
 

--- a/.github/workflows/openwrt-repair-mirror.yml
+++ b/.github/workflows/openwrt-repair-mirror.yml
@@ -1,0 +1,86 @@
+name: 修复 OpenWrt Beta 镜像文件名
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: '已修复 GitHub 附件与 SHA256SUMS 的 Beta 标签，例如 beta-1.4.8'
+        type: string
+        required: true
+      source_run_id:
+        description: '已成功完成镜像上传的 Beta 发布 run ID'
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: openwrt-repair-mirror-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  repair:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: 验证原发布已完成镜像上传
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$TAG" =~ ^beta-[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]
+          gh api "repos/${REPO}/actions/runs/${SOURCE_RUN_ID}" > source-run.json
+          jq -e '.path == ".github/workflows/daily-build-msm-beta.yml"' source-run.json
+          gh api "repos/${REPO}/actions/runs/${SOURCE_RUN_ID}/jobs?per_page=100" > source-jobs.json
+          jq -e '[.jobs[] | select(.name == "上传每日构建到自定义服务器")] | length == 1 and all(.[]; .status == "completed" and .conclusion == "success")' source-jobs.json
+          gh run download "$SOURCE_RUN_ID" --repo "$REPO" --name "msm-${TAG}-checksums" --dir source-checksums
+          gh api "repos/${REPO}/releases/tags/${TAG}" > release.json
+          gh release download "$TAG" --repo "$REPO" --pattern SHA256SUMS
+          node .github/openwrt/prepare-mirror-repair.cjs "$TAG" release.json SHA256SUMS source-checksums/SHA256SUMS repair-mirror.sh
+      - name: 安装 SSH 工具
+        run: sudo apt-get update -qq && sudo apt-get install -y sshpass
+      - name: 校验后修复镜像文件名和清单
+        env:
+          TAG: ${{ inputs.tag }}
+          EXTRA_SERVERS: ${{ secrets.DEPLOY_SERVERS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "$EXTRA_SERVERS" ]; then
+            echo 'error: DEPLOY_SERVERS is required for mirror repair' >&2
+            exit 1
+          fi
+          repaired=0
+          while IFS= read -r entry; do
+            [ -z "${entry//[[:space:]]/}" ] && continue
+            IFS=',' read -r host user pass target port <<< "$entry"
+            if [ -z "$host" ] || [ -z "$user" ] || [ -z "$pass" ] || [ -z "$target" ]; then
+              echo 'error: incomplete mirror configuration' >&2
+              exit 1
+            fi
+            [[ "$target" == /* ]]
+            SSH_ARGS=(-o StrictHostKeyChecking=no -o ConnectTimeout=20)
+            if [ -n "$port" ]; then
+              [[ "$port" =~ ^[0-9]+$ ]]
+              SSH_ARGS+=(-p "$port")
+            fi
+            printf -v directory_quoted '%q' "${target%/}/beta/${TAG}"
+            SSHPASS="$pass" sshpass -e ssh "${SSH_ARGS[@]}" "${user}@${host}" \
+              "bash -s -- ${directory_quoted}" < repair-mirror.sh
+            repaired=$((repaired + 1))
+          done <<< "$EXTRA_SERVERS"
+          [ "$repaired" -gt 0 ]
+          echo "Verified and repaired ${repaired} mirror server(s)"

--- a/test/openwrt-package-mirror.test.cjs
+++ b/test/openwrt-package-mirror.test.cjs
@@ -1,0 +1,118 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { prepareMirrorRepair } = require('../.github/openwrt/prepare-mirror-repair.cjs');
+
+function fixture() {
+  const tag = 'beta-1.4.8';
+  const arches = ['x86_64', 'aarch64_generic', 'aarch64_cortex-a53', 'aarch64_cortex-a72', 'arm_cortex-a7_neon-vfpv4', 'arm_cortex-a9_vfpv3-d16', 'arm_cortex-a9_neon', 'arm_cortex-a15_neon-vfpv4', 'arm_arm1176jzf-s_vfp'];
+  const names = arches.flatMap(arch => [`msm_1.4.8_beta-r1_${arch}.ipk`, `msm-1.4.8_beta-r1_${arch}.apk`]);
+  names.push('luci-app-msm_1.4.8_beta-r1_all.ipk', 'luci-app-msm-1.4.8_beta-r1_all.apk', 'msm-beta-1.4.8-darwin-arm64.tar.gz');
+  const files = new Map(names.map(name => [name, Buffer.from(`original:${name}\n`)]));
+  const sha256 = value => crypto.createHash('sha256').update(value).digest('hex');
+  const checksums = [...files].map(([name, data]) => `${sha256(data)}  ${name}\n`).join('');
+  const release = { tag_name: tag, draft: false, prerelease: true, assets: [...files].map(([name, data]) => ({ name, state: 'uploaded', digest: `sha256:${sha256(data)}` })) };
+  release.assets.push({ name: 'SHA256SUMS', state: 'uploaded', digest: `sha256:${sha256(checksums)}` });
+  return { tag, files, checksums, release };
+}
+
+function withMirror(action) {
+  const input = fixture();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'msm-openwrt-mirror-'));
+  const mirror = path.join(root, 'mirror with spaces');
+  const bin = path.join(root, 'bin');
+  fs.mkdirSync(mirror);
+  fs.mkdirSync(bin);
+  if (spawnSync('sha256sum', ['--version']).error) {
+    fs.writeFileSync(path.join(bin, 'sha256sum'), '#!/bin/sh\nexec shasum -a 256 "$@"\n', { mode: 0o755 });
+  }
+  if (spawnSync('mv', ['--version']).status !== 0) {
+    const gmv = spawnSync('which', ['gmv'], { encoding: 'utf8' }).stdout.trim();
+    assert.ok(gmv, 'GNU mv is required for mirror repair tests (brew install coreutils on macOS)');
+    fs.symlinkSync(gmv, path.join(bin, 'mv'));
+  }
+  let index = 0;
+  for (const [name, data] of input.files) {
+    const old = name.endsWith('.ipk') ? name.replace('_beta-', index++ % 2 ? '.beta-' : '~beta-') : name;
+    fs.writeFileSync(path.join(mirror, old), data);
+  }
+  fs.writeFileSync(path.join(mirror, 'SHA256SUMS'), input.checksums.split('\n').map(line => line.endsWith('.ipk') ? line.replace('_beta-r1_', '~beta-r1_') : line).join('\n'));
+  const run = () => spawnSync('bash', ['-s', '--', mirror], { input: prepareMirrorRepair(input.release, input.checksums, input.tag, input.checksums), encoding: 'utf8', env: { ...process.env, PATH: `${bin}:${process.env.PATH}` } });
+  try { action({ ...input, mirror, run }); } finally { fs.rmSync(root, { recursive: true, force: true }); }
+}
+
+test('mirror repair renames verified IPKs, preserves all package bytes and is idempotent', () => {
+  withMirror(({ files, checksums, mirror, run }) => {
+    const first = run();
+    assert.equal(first.status, 0, first.stderr || first.stdout);
+    for (const [name, data] of files) assert.deepEqual(fs.readFileSync(path.join(mirror, name)), data);
+    assert.equal(fs.readFileSync(path.join(mirror, 'SHA256SUMS'), 'utf8'), checksums);
+    for (const name of [...files.keys(), 'SHA256SUMS']) assert.equal(fs.statSync(path.join(mirror, name)).mode & 0o777, 0o644, name);
+    assert.deepEqual(fs.readdirSync(mirror).sort(), [...files.keys(), 'SHA256SUMS'].sort());
+    const second = run();
+    assert.equal(second.status, 0, second.stderr || second.stdout);
+    for (const name of [...files.keys(), 'SHA256SUMS']) assert.equal(fs.statSync(path.join(mirror, name)).mode & 0o777, 0o644, name);
+    assert.deepEqual(fs.readdirSync(mirror).sort(), [...files.keys(), 'SHA256SUMS'].sort());
+  });
+});
+
+test('mirror repair refuses damaged existing packages before replacing the checksum manifest', () => {
+  withMirror(({ mirror, run }) => {
+    const original = fs.readFileSync(path.join(mirror, 'SHA256SUMS'));
+    const other = path.join(mirror, 'msm-beta-1.4.8-darwin-arm64.tar.gz');
+    fs.writeFileSync(other, 'changed unrelated platform');
+    const before = fs.readdirSync(mirror).sort();
+    const result = run();
+    assert.notEqual(result.status, 0);
+    assert.deepEqual(fs.readdirSync(mirror).sort(), before);
+    assert.deepEqual(fs.readFileSync(path.join(mirror, 'SHA256SUMS')), original);
+    assert.equal(fs.readFileSync(other, 'utf8'), 'changed unrelated platform');
+  });
+});
+
+test('mirror repair rejects incomplete releases, wrong hashes and unsafe checksum paths', () => {
+  const input = fixture();
+  assert.throws(() => prepareMirrorRepair(input.release, input.checksums, 'beta-1.4.8/../../'), /numeric beta tag/);
+  assert.throws(() => prepareMirrorRepair({ ...input.release, assets: input.release.assets.slice(1) }, input.checksums, input.tag, input.checksums), /20 canonical/);
+  assert.throws(() => prepareMirrorRepair(input.release, input.checksums + '\n', input.tag), /published digest/);
+  assert.throws(() => prepareMirrorRepair(input.release, input.checksums, input.tag, input.checksums.replace('msm-beta-1.4.8-darwin-arm64.tar.gz', 'msm-beta-1.4.7-darwin-arm64.tar.gz')), /Original run tag\/content/);
+  assert.throws(() => prepareMirrorRepair(input.release, input.checksums, input.tag), /Original run checksum artifact/);
+  const source = input.checksums.split('\n').map(line => line.endsWith('.ipk') ? line.replace('_beta-r1_', '~beta-r1_') : line).join('\n');
+  assert.match(prepareMirrorRepair(input.release, input.checksums, input.tag, source), /check_file/);
+  const badRelease = structuredClone(input.release);
+  badRelease.assets[0].digest = `sha256:${'0'.repeat(64)}`;
+  assert.throws(() => prepareMirrorRepair(badRelease, input.checksums, input.tag, input.checksums), /checksum mismatch/);
+  const unsafe = input.checksums.replace('msm-beta-1.4.8-darwin-arm64.tar.gz', '../outside');
+  const unsafeRelease = structuredClone(input.release);
+  unsafeRelease.assets.find(asset => asset.name === 'SHA256SUMS').digest = `sha256:${crypto.createHash('sha256').update(unsafe).digest('hex')}`;
+  assert.throws(() => prepareMirrorRepair(unsafeRelease, unsafe, input.tag, input.checksums), /Unsafe/);
+});
+
+test('mirror repair never follows a canonical package symlink', () => {
+  withMirror(({ mirror, run }) => {
+    fs.symlinkSync('msm-beta-1.4.8-darwin-arm64.tar.gz', path.join(mirror, 'msm_1.4.8_beta-r1_x86_64.ipk'));
+    assert.notEqual(run().status, 0);
+  });
+});
+
+for (const invalid of ['missing', 'directory', 'directory-symlink']) {
+  test(`mirror repair rejects a ${invalid} checksum manifest without changing any packages`, () => {
+    withMirror(({ mirror, run }) => {
+      const manifest = path.join(mirror, 'SHA256SUMS');
+      fs.rmSync(manifest);
+      if (invalid === 'directory') fs.mkdirSync(manifest);
+      if (invalid === 'directory-symlink') {
+        fs.mkdirSync(path.join(mirror, 'outside'));
+        fs.symlinkSync('outside', manifest);
+      }
+      const before = fs.readdirSync(mirror).sort();
+      assert.notEqual(run().status, 0);
+      assert.deepEqual(fs.readdirSync(mirror).sort(), before);
+      if (invalid === 'directory-symlink') assert.deepEqual(fs.readdirSync(path.join(mirror, 'outside')), []);
+    });
+  });
+}


### PR DESCRIPTION
Beta IPK asset names originally contained `~`, which GitHub normalized and left mirror filenames inconsistent with corrected release checksums. Add a manually dispatched mirror repair that binds a numeric Beta tag to the original successful upload run and its exact checksum artifact, then compares every hash against the corrected GitHub release.

The remote script validates all existing files before mutation, preserves package bytes, makes canonical IPK names and the checksum manifest readable, atomically replaces the verified manifest, and removes only verified legacy aliases. Other platform packages remain unchanged. The workflow has read-only GitHub permissions and uses the existing mirror secret only for the SSH repair step.

Validation: 35 local tests passed; the opt-in real APK test is exercised by the PR workflow. Seven mirror shell tests cover idempotence, mode 0644, damaged packages, source run/content mismatch, and unsafe paths/symlinks. Actionlint passed all four related workflows. The actual beta-1.4.8 source run checksum artifact and corrected release metadata also generated a valid repair script without executing it.
