### PR TITLE
fix(ci): 修复稳定镜像恢复的摘要读取 / fix digest reading during stable recovery

### DIFF
--- a/.github/workflows/restore-stable-1.2.6.yml
+++ b/.github/workflows/restore-stable-1.2.6.yml
@@ -96,11 +96,11 @@ jobs:
           original='sha256:1ac73464a72ecaec5268cb04e270976c0c631230838e363362e503c16616a344'
           withdrawn='sha256:1fcdd290138ae19d80a4ada22a8777b8b904b08f49c5d913e0fe7b8a052a434c'
           for tag in 1.2.6 latest; do
-            current=$(docker buildx imagetools inspect "msmbox/msm:${tag}" | awk '$1 == "Digest:" {print $2; exit}')
+            current=$(docker buildx imagetools inspect "msmbox/msm:${tag}" --format '{{.Manifest.Digest}}')
             [ "$current" = "$original" ] || [ "$current" = "$withdrawn" ]
           done
           docker buildx imagetools create --tag msmbox/msm:1.2.6 --tag msmbox/msm:latest "msmbox/msm@${original}"
           for tag in 1.2.6 latest; do
-            current=$(docker buildx imagetools inspect "msmbox/msm:${tag}" | awk '$1 == "Digest:" {print $2; exit}')
+            current=$(docker buildx imagetools inspect "msmbox/msm:${tag}" --format '{{.Manifest.Digest}}')
             [ "$current" = "$original" ]
           done


### PR DESCRIPTION
恢复原稳定版镜像时，摘要提取管道中的 awk 提前退出，会导致 Docker CLI 在 pipefail 下以 255 结束，阻断标签恢复。改用 Docker Buildx 原生 --format 输出摘要，保留所有原始/待撤摘要检查。

验证：真实 Docker Hub 镜像摘要读取成功；actionlint 和 git diff --check 通过。原文件镜像恢复步骤已成功且可幂等重跑。
